### PR TITLE
Parse growatt register tables into JSON files

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -249,6 +249,26 @@ ha core stop && docker run --rm -it --device=$SER:/dev/ttyUSB0 -v "$REPO":/app -
   sh -lc 'pip install -q "pymodbus[serial]>=3.8,<3.9" && PYTHONPATH=/app SERIAL_PORT=/dev/ttyUSB0 python /app/read_registers.py' && ha core start
 ```
 
+## Parsing register specification
+
+`parse_registers.py` converts the in-repo documentation
+`growatt_registers.md` into machine readable JSON files. Run from this
+directory:
+
+```bash
+python parse_registers.py
+```
+
+The script writes four outputs:
+
+* `holding_min.json`
+* `holding_tl_xh.json`
+* `input_min.json`
+* `input_tl_xh.json`
+
+Each entry records register number, function code, length, scale, unit,
+and description for the corresponding device type.
+
 ---
 
 *Happy hacking and safe debugging!*

--- a/testing/holding_min.json
+++ b/testing/holding_min.json
@@ -1,0 +1,434 @@
+[
+  {
+    "number": 0,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "Remote On/Off"
+  },
+  {
+    "number": 3,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "%",
+    "description": "Max active power %"
+  },
+  {
+    "number": 5,
+    "function_code": "03",
+    "length": 1,
+    "scale": 10000,
+    "unit": "-",
+    "description": "Power factor ×10000"
+  },
+  {
+    "number": 7,
+    "function_code": "03",
+    "length": 2,
+    "scale": 1,
+    "unit": "VA",
+    "description": "Normal power setting"
+  },
+  {
+    "number": 9,
+    "function_code": "03",
+    "length": 3,
+    "scale": 1,
+    "unit": "ASCII",
+    "description": "Firmware version"
+  },
+  {
+    "number": 12,
+    "function_code": "03",
+    "length": 3,
+    "scale": 1,
+    "unit": "ASCII",
+    "description": "Control firmware version"
+  },
+  {
+    "number": 15,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "code",
+    "description": "LCD language"
+  },
+  {
+    "number": 17,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "PV start voltage"
+  },
+  {
+    "number": 18,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "s",
+    "description": "Start time"
+  },
+  {
+    "number": 19,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "s",
+    "description": "Restart delay after fault"
+  },
+  {
+    "number": 20,
+    "function_code": "03",
+    "length": 2,
+    "scale": 1,
+    "unit": "%/s",
+    "description": "Power slope settings"
+  },
+  {
+    "number": 22,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "Baud rate selection"
+  },
+  {
+    "number": 23,
+    "function_code": "03",
+    "length": 5,
+    "scale": 1,
+    "unit": "str",
+    "description": "Serial number (ASCII)"
+  },
+  {
+    "number": 28,
+    "function_code": "03",
+    "length": 2,
+    "scale": 1,
+    "unit": "str",
+    "description": "Inverter model"
+  },
+  {
+    "number": 30,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "Communication address"
+  },
+  {
+    "number": 31,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "Flash update trigger"
+  },
+  {
+    "number": 34,
+    "function_code": "03",
+    "length": 8,
+    "scale": 1,
+    "unit": "-",
+    "description": "Manufacturer info"
+  },
+  {
+    "number": 43,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "`ATTR_DEVICE_TYPE_CODE`",
+    "description": "Device type code"
+  },
+  {
+    "number": 44,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "`ATTR_NUMBER_OF_TRACKERS_AND_PHASES`",
+    "description": "Tracker + phase count"
+  },
+  {
+    "number": 45,
+    "function_code": "03",
+    "length": 6,
+    "scale": 1,
+    "unit": "-",
+    "description": "Device system time (Y/M/D/H/M/S)"
+  },
+  {
+    "number": 82,
+    "function_code": "03",
+    "length": 6,
+    "scale": 1,
+    "unit": "-",
+    "description": "FW build numbers (ASCII)"
+  },
+  {
+    "number": 88,
+    "function_code": "03",
+    "length": 1,
+    "scale": 100,
+    "unit": "`ATTR_MODBUS_VERSION`",
+    "description": "Modbus version ×100"
+  },
+  {
+    "number": 0,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "Remote On/Off (Inverter/BDC)"
+  },
+  {
+    "number": 1,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "Safety function enable bits"
+  },
+  {
+    "number": 2,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "PF CMD memory state"
+  },
+  {
+    "number": 3,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "%",
+    "description": "Active P rate (limit %)"
+  },
+  {
+    "number": 4,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "%",
+    "description": "Reactive P rate (limit %)"
+  },
+  {
+    "number": 5,
+    "function_code": "03",
+    "length": 1,
+    "scale": 10000,
+    "unit": "–",
+    "description": "Power factor ×10000"
+  },
+  {
+    "number": 6,
+    "function_code": "03",
+    "length": 2,
+    "scale": 1,
+    "unit": "VA",
+    "description": "Pmax (high/low)"
+  },
+  {
+    "number": 8,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "Vnormal (PV work voltage)"
+  },
+  {
+    "number": 9,
+    "function_code": "03",
+    "length": 3,
+    "scale": 1,
+    "unit": "–",
+    "description": "Firmware version (H/M/L)"
+  },
+  {
+    "number": 12,
+    "function_code": "03",
+    "length": 3,
+    "scale": 1,
+    "unit": "–",
+    "description": "Control FW version (H/M/L)"
+  },
+  {
+    "number": 15,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "LCD language"
+  },
+  {
+    "number": 16,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "Country selected"
+  },
+  {
+    "number": 17,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "PV start voltage"
+  },
+  {
+    "number": 18,
+    "function_code": "03",
+    "length": 2,
+    "scale": 1,
+    "unit": "s",
+    "description": "Start / Restart delay"
+  },
+  {
+    "number": 20,
+    "function_code": "03",
+    "length": 2,
+    "scale": 1,
+    "unit": "0.1%",
+    "description": "Power start / restart slope"
+  },
+  {
+    "number": 22,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "Baudrate select (0=9600,1=38400)"
+  },
+  {
+    "number": 23,
+    "function_code": "03",
+    "length": 5,
+    "scale": 1,
+    "unit": "–",
+    "description": "Serial number (1–10)"
+  },
+  {
+    "number": 28,
+    "function_code": "03",
+    "length": 2,
+    "scale": 1,
+    "unit": "–",
+    "description": "Inverter Module (model code)"
+  },
+  {
+    "number": 30,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "Modbus address"
+  },
+  {
+    "number": 31,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "FlashStart (FW update)"
+  },
+  {
+    "number": 32,
+    "function_code": "03",
+    "length": 2,
+    "scale": 1,
+    "unit": "–",
+    "description": "Reset user info / factory"
+  },
+  {
+    "number": 34,
+    "function_code": "03",
+    "length": 8,
+    "scale": 1,
+    "unit": "–",
+    "description": "Manufacturer info (8..1)"
+  },
+  {
+    "number": 42,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "G100 fail safe"
+  },
+  {
+    "number": 43,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "Device Type Code"
+  },
+  {
+    "number": 44,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "Trackers & phases"
+  },
+  {
+    "number": 45,
+    "function_code": "03",
+    "length": 7,
+    "scale": 1,
+    "unit": "–",
+    "description": "System time (Y/M/D/h/m/s/weekday)"
+  },
+  {
+    "number": 52,
+    "function_code": "03",
+    "length": 16,
+    "scale": 1,
+    "unit": "–",
+    "description": "Grid protection limits"
+  },
+  {
+    "number": 68,
+    "function_code": "03",
+    "length": 12,
+    "scale": 1,
+    "unit": "–",
+    "description": "Grid protection times"
+  },
+  {
+    "number": 80,
+    "function_code": "03",
+    "length": 2,
+    "scale": 1,
+    "unit": "–",
+    "description": "10‑min voltage / PV over‑V fault"
+  },
+  {
+    "number": 82,
+    "function_code": "03",
+    "length": 6,
+    "scale": 1,
+    "unit": "–",
+    "description": "FW build numbers"
+  },
+  {
+    "number": 88,
+    "function_code": "03",
+    "length": 1,
+    "scale": 100,
+    "unit": "–",
+    "description": "Modbus version ×100"
+  },
+  {
+    "number": 89,
+    "function_code": "03",
+    "length": 11,
+    "scale": 1,
+    "unit": "–",
+    "description": "PF/Q(V)/derating controls"
+  }
+]

--- a/testing/holding_tl_xh.json
+++ b/testing/holding_tl_xh.json
@@ -1,0 +1,18 @@
+[
+  {
+    "number": 3001,
+    "function_code": "03",
+    "length": 15,
+    "scale": 1,
+    "unit": "–",
+    "description": "Serial number (ASCII, 15 words)"
+  },
+  {
+    "number": 3049,
+    "function_code": "03",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "AC charge enable"
+  }
+]

--- a/testing/input_min.json
+++ b/testing/input_min.json
@@ -1,0 +1,450 @@
+[
+  {
+    "number": 0,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "int",
+    "description": "Status code"
+  },
+  {
+    "number": 1,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "W",
+    "description": "Total PV input power"
+  },
+  {
+    "number": 3,
+    "function_code": "04",
+    "length": 4,
+    "scale": 1,
+    "unit": "V/A/W",
+    "description": "PV1 V/A/P"
+  },
+  {
+    "number": 7,
+    "function_code": "04",
+    "length": 4,
+    "scale": 1,
+    "unit": "V/A/W",
+    "description": "PV2 V/A/P"
+  },
+  {
+    "number": 35,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "W",
+    "description": "Output power"
+  },
+  {
+    "number": 37,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "Hz",
+    "description": "Grid frequency"
+  },
+  {
+    "number": 38,
+    "function_code": "04",
+    "length": 3,
+    "scale": 1,
+    "unit": "V/A/W",
+    "description": "AC1 V/A/P"
+  },
+  {
+    "number": 53,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "Today’s output energy"
+  },
+  {
+    "number": 55,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "Total output energy"
+  },
+  {
+    "number": 57,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "h",
+    "description": "Operation hours"
+  },
+  {
+    "number": 59,
+    "function_code": "04",
+    "length": 8,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "PV1+PV2 today & total energy"
+  },
+  {
+    "number": 91,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "PV total energy"
+  },
+  {
+    "number": 93,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "°C",
+    "description": "Inverter temp"
+  },
+  {
+    "number": 94,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "°C",
+    "description": "IPM temp"
+  },
+  {
+    "number": 98,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "P-bus voltage"
+  },
+  {
+    "number": 99,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "N-bus voltage"
+  },
+  {
+    "number": 101,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "%",
+    "description": "Output %"
+  },
+  {
+    "number": 104,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "Derating mode"
+  },
+  {
+    "number": 105,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "Fault code"
+  },
+  {
+    "number": 110,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "Warning code"
+  },
+  {
+    "number": 0,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "Status code"
+  },
+  {
+    "number": 1,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "W",
+    "description": "PV total input power"
+  },
+  {
+    "number": 3,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "PV1 voltage"
+  },
+  {
+    "number": 4,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "A",
+    "description": "PV1 current"
+  },
+  {
+    "number": 5,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "W",
+    "description": "PV1 power"
+  },
+  {
+    "number": 7,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "PV2 voltage"
+  },
+  {
+    "number": 8,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "A",
+    "description": "PV2 current"
+  },
+  {
+    "number": 9,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "W",
+    "description": "PV2 power"
+  },
+  {
+    "number": 11,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "PV3 voltage"
+  },
+  {
+    "number": 12,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "A",
+    "description": "PV3 current"
+  },
+  {
+    "number": 13,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "W",
+    "description": "PV3 power"
+  },
+  {
+    "number": 15,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "PV4 voltage"
+  },
+  {
+    "number": 16,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "A",
+    "description": "PV4 current"
+  },
+  {
+    "number": 17,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "W",
+    "description": "PV4 power"
+  },
+  {
+    "number": 35,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "W",
+    "description": "Output (AC) power"
+  },
+  {
+    "number": 37,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "Hz",
+    "description": "Grid frequency"
+  },
+  {
+    "number": 38,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "AC1 voltage"
+  },
+  {
+    "number": 39,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "A",
+    "description": "AC1 current"
+  },
+  {
+    "number": 40,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "W",
+    "description": "AC1 power"
+  },
+  {
+    "number": 42,
+    "function_code": "04",
+    "length": 7,
+    "scale": 1,
+    "unit": "–",
+    "description": "AC2/AC3 (3‑phase models)"
+  },
+  {
+    "number": 53,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "Today’s output energy"
+  },
+  {
+    "number": 55,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "Total output energy"
+  },
+  {
+    "number": 57,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "h",
+    "description": "Operation hours"
+  },
+  {
+    "number": 59,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "PV1 today’s energy"
+  },
+  {
+    "number": 61,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "PV1 total energy"
+  },
+  {
+    "number": 63,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "PV2 today’s energy"
+  },
+  {
+    "number": 65,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "PV2 total energy"
+  },
+  {
+    "number": 91,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "PV total energy"
+  },
+  {
+    "number": 93,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "°C",
+    "description": "Inverter temperature"
+  },
+  {
+    "number": 94,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "°C",
+    "description": "IPM temperature"
+  },
+  {
+    "number": 98,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "DC bus voltage P"
+  },
+  {
+    "number": 99,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "V",
+    "description": "DC bus voltage N"
+  },
+  {
+    "number": 101,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "%",
+    "description": "Real output %"
+  },
+  {
+    "number": 104,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "Derating mode"
+  },
+  {
+    "number": 105,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "Fault code"
+  },
+  {
+    "number": 110,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "–",
+    "description": "Warning code"
+  }
+]

--- a/testing/input_tl_xh.json
+++ b/testing/input_tl_xh.json
@@ -1,0 +1,114 @@
+[
+  {
+    "number": 3125,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "Battery discharge today"
+  },
+  {
+    "number": 3127,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "Battery discharge total"
+  },
+  {
+    "number": 3129,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "Battery charge today"
+  },
+  {
+    "number": 3131,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "kWh",
+    "description": "Battery charge total"
+  },
+  {
+    "number": 3164,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "BDC new flag"
+  },
+  {
+    "number": 3171,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "%",
+    "description": "Battery SOC %"
+  },
+  {
+    "number": 3176,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "°C",
+    "description": "Battery temp A"
+  },
+  {
+    "number": 3177,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "°C",
+    "description": "Battery temp B"
+  },
+  {
+    "number": 3178,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "W",
+    "description": "Battery discharge power"
+  },
+  {
+    "number": 3180,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "W",
+    "description": "Battery charge power"
+  },
+  {
+    "number": 3069,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "",
+    "description": "32‑bit field (pair)"
+  },
+  {
+    "number": 3097,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "",
+    "description": "Communication board temperature"
+  },
+  {
+    "number": 3111,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "",
+    "description": "PresentFFTValue \\[CHANNEL_A]"
+  },
+  {
+    "number": 3115,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "",
+    "description": "Inverter start delay time"
+  }
+]

--- a/testing/parse_registers.py
+++ b/testing/parse_registers.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Parse growatt_registers.md into JSON register maps.
+
+Outputs separate JSON files for holding and input registers and
+splits entries into MIN (<3000) and TL-XH (>=3000) groups.
+Each record contains register number, Modbus function code, length,
+scale (if detectable), unit, and description.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+
+def parse_registers(md_path: pathlib.Path):
+    data = {
+        "holding_min": [],
+        "holding_tl_xh": [],
+        "input_min": [],
+        "input_tl_xh": [],
+    }
+
+    current_fc = None  # '03' or '04'
+    in_table = False
+
+    lines = md_path.read_text(encoding="utf-8").splitlines()
+    for line in lines:
+        line = line.rstrip()
+
+        # Section switches determine function code
+        if line.startswith("# "):
+            if "Holding Registers" in line:
+                current_fc = "03"
+            elif "Input Registers" in line:
+                current_fc = "04"
+            else:
+                current_fc = None
+            in_table = False
+            continue
+
+        # Table header / separator handling
+        if line.startswith("|"):
+            cols = [c.strip() for c in line.strip().split("|")[1:-1]]
+            if cols and cols[0].lower() == "register":
+                in_table = True
+                continue
+            if not in_table or set(cols[0]) <= {"", "-"}:
+                continue
+
+            reg_text = cols[0]
+            m = re.match(r"(\d+)\s*[–-]\s*(\d+)", reg_text)
+            if m:
+                start = int(m.group(1))
+                end = int(m.group(2))
+            else:
+                m = re.match(r"(\d+)", reg_text)
+                if not m:
+                    continue
+                start = end = int(m.group(1))
+            length = end - start + 1
+
+            desc = cols[1] if len(cols) > 1 else ""
+            unit = cols[2] if len(cols) > 2 else ""
+            notes = cols[4] if len(cols) > 4 else (cols[3] if len(cols) > 3 else "")
+
+            scale = 1
+            m_scale = re.search(r"×\s?(\d+)", desc) or re.search(r"×\s?(\d+)", notes)
+            if m_scale:
+                try:
+                    scale = int(m_scale.group(1))
+                except ValueError:
+                    pass
+
+            entry = {
+                "number": start,
+                "function_code": current_fc,
+                "length": length,
+                "scale": scale,
+                "unit": unit,
+                "description": desc,
+            }
+
+            group = "tl_xh" if start >= 3000 else "min"
+            key = f"{'holding' if current_fc == '03' else 'input'}_{group}"
+            data[key].append(entry)
+        else:
+            in_table = False
+
+    return data
+
+
+def main():
+    base = pathlib.Path(__file__).resolve().parent
+    md_path = base / "growatt_registers.md"
+    registers = parse_registers(md_path)
+
+    for name, entries in registers.items():
+        out_path = base / f"{name}.json"
+        with out_path.open("w", encoding="utf-8") as fh:
+            json.dump(entries, fh, indent=2, ensure_ascii=False)
+        print(f"Wrote {out_path} ({len(entries)} records)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `parse_registers.py` to convert `growatt_registers.md` tables to JSON
- generate JSON maps for holding/input registers split between MIN and TL-XH ranges
- document register parsing workflow in testing README

## Testing
- `python testing/parse_registers.py`
- `python -m py_compile testing/parse_registers.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1b1bf0700833082dc13d4dcca597b