### PR TITLE
Map TL-XH board temperature and diagnostics registers

### DIFF
--- a/custom_components/growatt_local/API/device_type/base.py
+++ b/custom_components/growatt_local/API/device_type/base.py
@@ -137,7 +137,12 @@ ATTR_DISCHARGE_ENERGY_TOTAL = "discharge_energy_total"  # kWh
 ATTR_CHARGE_ENERGY_TODAY = "charge_energy_today"  # kWh
 ATTR_CHARGE_ENERGY_TOTAL = "charge_energy_total"  # kWh
 
-# Attribute names for values in the input register for Offgrid inverter 
+# Additional TL-XH input attributes
+ATTR_COMM_BOARD_TEMPERATURE = "comm_board_temperature"  # C
+ATTR_PRESENT_FFT_A = "present_fft_a"
+ATTR_INV_START_DELAY = "inv_start_delay"  # s
+
+# Attribute names for values in the input register for Offgrid inverter
 ATTR_ACTIVE_POWER = "output_active_power"  # W
 
 ATTR_BATTERY_VOLTAGE = "battery_voltage"  # V

--- a/custom_components/growatt_local/API/device_type/storage_120.py
+++ b/custom_components/growatt_local/API/device_type/storage_120.py
@@ -29,6 +29,9 @@ from .base import (
     ATTR_BDC_NEW_FLAG,
     ATTR_BATTERY_TEMPERATURE_A,
     ATTR_BATTERY_TEMPERATURE_B,
+    ATTR_COMM_BOARD_TEMPERATURE,
+    ATTR_PRESENT_FFT_A,
+    ATTR_INV_START_DELAY,
 )
 
 MAXIMUM_DATA_LENGTH = 100
@@ -161,6 +164,15 @@ STORAGE_INPUT_REGISTERS_120_TL_XH: tuple[GrowattDeviceRegisters, ...] = (
     ),
     GrowattDeviceRegisters(
         name=ATTR_ENERGY_TO_GRID_TOTAL, register=3073, value_type=float, length=2
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_COMM_BOARD_TEMPERATURE, register=3097, value_type=float
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_PRESENT_FFT_A, register=3111, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_INV_START_DELAY, register=3115, value_type=int
     ),
     GrowattDeviceRegisters(
         name=ATTR_DISCHARGE_ENERGY_TODAY, register=3125, value_type=float, length=2

--- a/testing/growatt_registers.md
+++ b/testing/growatt_registers.md
@@ -438,6 +438,7 @@ Add these to `base.py` if they’re missing; names match the tables above so you
 ATTR_VAC_RS = "vac_rs"                      # V, 3038
 ATTR_VAC_ST = "vac_st"                      # V, 3039
 ATTR_VAC_TR = "vac_tr"                      # V, 3040
+ATTR_COMM_BOARD_TEMPERATURE = "comm_board_temperature"    # C, 3097
 ATTR_PRESENT_FFT_A = "present_fft_a"        # 3111
 ATTR_AFCI_STATUS = "afci_status"            # 3112
 ATTR_AFCI_STRENGTH_A = "afci_strength_a"    # 3113


### PR DESCRIPTION
## Summary
- expose TL-XH communication board temperature, FFT value and inverter start delay registers
- document new TL-XH attributes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1c3bc37bc833095609c9b0ee491d3