### PR TITLE
Add reactive power register mapping for TL-XH storage

### DIFF
--- a/custom_components/growatt_local/API/device_type/storage_120.py
+++ b/custom_components/growatt_local/API/device_type/storage_120.py
@@ -11,6 +11,7 @@ from .base import (
     ATTR_SOC_PERCENTAGE,
     ATTR_DISCHARGE_POWER,
     ATTR_CHARGE_POWER,
+    ATTR_OUTPUT_REACTIVE_POWER,
     ATTR_POWER_TO_USER,
     ATTR_POWER_TO_GRID,
     ATTR_POWER_USER_LOAD,
@@ -143,6 +144,9 @@ STORAGE_INPUT_REGISTERS_120_TL_XH: tuple[GrowattDeviceRegisters, ...] = (
     ),
     GrowattDeviceRegisters(
         name=ATTR_CHARGE_POWER, register=3180, value_type=float, length=2
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_OUTPUT_REACTIVE_POWER, register=3021, value_type=float, length=2
     ),
     GrowattDeviceRegisters(
         name=ATTR_POWER_TO_USER, register=3041, value_type=float, length=2

--- a/testing/growatt_registers.md
+++ b/testing/growatt_registers.md
@@ -90,7 +90,7 @@ Various PF/Q(V) models, grid curves, and frequency derating settings appear here
 
 ### Extended Measurements (3000–3124)
 Mirror of 0–124, but also includes:
-- 3021: Reactive power → `ATTR_OUTPUT_REACTIVE_POWER`
+- 3021: Reactive power (Var) → `ATTR_OUTPUT_REACTIVE_POWER` (`STORAGE_INPUT_REGISTERS_120_TL_XH`)
 - 3047: Operation hours (duplicate)
 - 3067–3074: To-user / To-grid energy stats → `ATTR_ENERGY_TO_*`
 
@@ -597,7 +597,7 @@ Use the list below to extend tables in your device modules (copy/paste). **All r
 - `ATTR_ENERGY_TO_USER_TOTAL` → **3069–3070** (kWh), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
 - `ATTR_ENERGY_TO_GRID_TODAY` → **3071–3072** (kWh), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
 - `ATTR_ENERGY_TO_GRID_TOTAL` → **3073–3074** (kWh), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
-- `ATTR_OUTPUT_REACTIVE_POWER` → **3021** (Var), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
+- `ATTR_OUTPUT_REACTIVE_POWER` → **3021** (Var), set: `STORAGE_INPUT_REGISTERS_120_TL_XH` *(implemented)*
 - `ATTR_SOC_PERCENTAGE` → **3171** (%), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
 - `ATTR_BDC_NEW_FLAG` → **3164** (–), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
 - `ATTR_BATTERY_TEMPERATURE_A` → **3176** (°C), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`

--- a/testing/input_tl_xh.json
+++ b/testing/input_tl_xh.json
@@ -1,5 +1,13 @@
 [
   {
+    "number": 3021,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "Var",
+    "description": "Reactive power (Qac H/L)"
+  },
+  {
     "number": 3041,
     "function_code": "04",
     "length": 2,


### PR DESCRIPTION
## Summary
- map reactive power register 3021 in TL-XH storage registers
- note the register and mapping in growatt_registers documentation and JSON

## Testing
- `python -m py_compile custom_components/growatt_local/API/device_type/storage_120.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1cd471508833086369d28bdae704f