### PR TITLE
Add TL-XH specific holding registers

### DIFF
--- a/custom_components/growatt_local/API/device_type/storage_120.py
+++ b/custom_components/growatt_local/API/device_type/storage_120.py
@@ -74,11 +74,31 @@ STORAGE_HOLDING_REGISTERS_120: tuple[GrowattDeviceRegisters, ...] = (
         value_type=float,
         scale=100
     ),
+)
+
+STORAGE_HOLDING_REGISTERS_120_TL_XH: tuple[GrowattDeviceRegisters, ...] = (
+    FIRMWARE_REGISTER,
+    GrowattDeviceRegisters(
+        name=ATTR_INVERTER_MODEL,
+        register=28,
+        value_type=custom_function,
+        length=2,
+        function=model,
+    ),
+    DEVICE_TYPE_CODE_REGISTER,
+    NUMBER_OF_TRACKERS_AND_PHASES_REGISTER,
+    GrowattDeviceRegisters(
+        name=ATTR_MODBUS_VERSION,
+        register=88,
+        value_type=float,
+        scale=100,
+    ),
+    SERIAL_NUMBER_REGISTER,
     GrowattDeviceRegisters(
         name=ATTR_AC_CHARGE_ENABLED,
         register=3049,
         value_type=int,
-        length=1
+        length=1,
     ),
 )
 

--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -36,7 +36,12 @@ from .device_type.base import (
     inverter_status,
 )
 from .device_type.inverter_120 import MAXIMUM_DATA_LENGTH_120, HOLDING_REGISTERS_120, INPUT_REGISTERS_120, INPUT_REGISTERS_120_TL_XH
-from .device_type.storage_120 import STORAGE_HOLDING_REGISTERS_120, STORAGE_INPUT_REGISTERS_120, STORAGE_INPUT_REGISTERS_120_TL_XH
+from .device_type.storage_120 import (
+    STORAGE_HOLDING_REGISTERS_120,
+    STORAGE_HOLDING_REGISTERS_120_TL_XH,
+    STORAGE_INPUT_REGISTERS_120,
+    STORAGE_INPUT_REGISTERS_120_TL_XH,
+)
 from .device_type.inverter_315 import MAXIMUM_DATA_LENGTH_315, HOLDING_REGISTERS_315, INPUT_REGISTERS_315
 from .device_type.offgrid import INPUT_REGISTERS_OFFGRID, offgrid_status
 
@@ -433,14 +438,11 @@ def get_register_information(GrowattDeviceType: DeviceTypes) -> DeviceRegisters:
     elif GrowattDeviceType == DeviceTypes.HYBRID_120_TL_XH:
         max_length = MAXIMUM_DATA_LENGTH_120
         holding_register = {
-            obj.register: obj for obj in STORAGE_HOLDING_REGISTERS_120
+            obj.register: obj for obj in STORAGE_HOLDING_REGISTERS_120_TL_XH
         }
         input_register = {
-            obj.register: obj for obj in INPUT_REGISTERS_120
-        }
-        input_register.update({
             obj.register: obj for obj in INPUT_REGISTERS_120_TL_XH
-        })
+        }
         input_register.update({
             obj.register: obj for obj in STORAGE_INPUT_REGISTERS_120_TL_XH
         })

--- a/testing/growatt_registers.md
+++ b/testing/growatt_registers.md
@@ -574,16 +574,18 @@ ATTR_DEBUG_DATA_16 = "debug_data_16"
 
 ## Hybrid / Extended Holding (TL‑XH)
 
-For TL‑XH systems we should introduce a dedicated holding set:
+For TL‑XH systems we use a dedicated holding set that mirrors the base
+`STORAGE_HOLDING_REGISTERS_120` entries and adds TL‑XH‑only addresses.
+The serial number range (3001–3015) is shared with the base set, while
+AC‑charge enable (3049) is TL‑XH specific:
 
 - **Set name**: `STORAGE_HOLDING_REGISTERS_120_TL_XH`
-- Purpose: all holding registers ≥3000 for TL‑XH hybrid inverters.
+- Purpose: TL‑XH holding registers, preferring the >3000 range where available.
 
 | Register | Name / Description             | Unit | Integration Attribute       | Notes |
 |----------|--------------------------------|------|-----------------------------|-------|
-| 3001–3015| Serial number (ASCII, 15 words)| –    | `ATTR_SERIAL_NUMBER`        | Already used by integration (mappable to TL‑XH set)
-| 3049     | AC charge enable               | –    | `ATTR_AC_CHARGE_ENABLED`    | Move here from generic storage holding
-
+| 3001–3015| Serial number (ASCII, 15 words)| –    | `ATTR_SERIAL_NUMBER`        | common |
+| 3049     | AC charge enable               | –    | `ATTR_AC_CHARGE_ENABLED`    | TL‑XH only |
 ---
 
 # Attributes to Add / Bind (TL‑XH)


### PR DESCRIPTION
## Summary
- mirror base holding registers in STORAGE_HOLDING_REGISTERS_120_TL_XH and add AC charge enable while keeping the serial number range in the base set
- dispatch TL-XH hybrids only to their dedicated holding and input register sets
- clarify TL-XH holding set in growatt_registers.md, noting the shared serial number range

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1cf1a7724833096caea6fd1fe606f