### PR TITLE
Prefer 'unit' kwarg when accessing holding registers

### DIFF
--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -77,7 +77,7 @@ class GrowattModbusBase:
         """Return the correct keyword for unit id depending on pymodbus version."""
         if self._unit_id_kwarg is None:
             params = inspect.signature(self.client.read_holding_registers).parameters
-            self._unit_id_kwarg = "slave" if "slave" in params else "unit"
+            self._unit_id_kwarg = "unit" if "unit" in params else "slave"
         return self._unit_id_kwarg
 
     async def get_device_info(


### PR DESCRIPTION
## Summary
- Ensure pymodbus unit-id keyword detection favors `unit` over deprecated `slave`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc0583e98883308d5faf632d1c363b