### PR TITLE
Refactor for pymodbus v3 compatibility

### DIFF
--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -75,7 +75,7 @@ class GrowattModbusBase:
             self,
             register: dict[int, GrowattDeviceRegisters] | tuple[GrowattDeviceRegisters, ...],
             max_length: int,
-            slave: int
+            unit: int
     ) -> GrowattDeviceInfo:
         """
         Read Growatt device information.
@@ -90,7 +90,7 @@ class GrowattModbusBase:
 
         for item in key_sequences:
             register_values.update(
-                await self.read_holding_registers(item[0], count=item[1], slave=slave)
+                await self.read_holding_registers(item[0], count=item[1], unit=unit)
             )
 
         results = process_registers(register, register_values)
@@ -107,23 +107,23 @@ class GrowattModbusBase:
 
         return device_info
 
-    async def read_device_time(self, slave: int):
+    async def read_device_time(self, unit: int):
         """
         Read Growatt device time.
         """
         # TODO: update with dynamic register values
-        rhr = await self.client.read_holding_registers(45, count=6, slave=slave)
+        rhr = await self.client.read_holding_registers(45, count=6, device_id=unit)
         if rhr.isError():
             _LOGGER.debug("Modbus read failed for rhr")
             raise ModbusException("Modbus read failed for rhr.")
 
         return datetime(
-            rhr.register[0] + 2000,
-            rhr.register[1],
-            rhr.register[2],
-            rhr.register[3],
-            rhr.register[4],
-            rhr.register[5],
+            rhr.registers[0] + 2000,
+            rhr.registers[1],
+            rhr.registers[2],
+            rhr.registers[3],
+            rhr.registers[4],
+            rhr.registers[5],
         )
 
     async def write_device_time(
@@ -139,17 +139,17 @@ class GrowattModbusBase:
         await self.client.write_register(49, minute)
         await self.client.write_register(50, second)
 
-    async def write_register(self, register, value, slave) -> ModbusPDU:  
+    async def write_register(self, register, value, unit) -> ModbusPDU:
         payload = ModbusBaseClient.convert_to_registers(value, ModbusBaseClient.DATATYPE.INT16)
-        return await self.client.write_register(register, payload[0], slave=slave)
+        return await self.client.write_register(register, payload[0], device_id=unit)
 
-    async def read_holding_registers(self, start_address, count, slave) -> dict[int, int]:
-        data = await self.client.read_holding_registers(start_address, count=count, slave=slave)
+    async def read_holding_registers(self, start_address, count, unit) -> dict[int, int]:
+        data = await self.client.read_holding_registers(start_address, count=count, device_id=unit)
         registers = {c: v for c, v in enumerate(data.registers, start_address)}
         return registers
 
-    async def read_input_registers(self, start_address, count, slave) -> dict[int, int]:
-        data = await self.client.read_input_registers(start_address, count=count, slave=slave)
+    async def read_input_registers(self, start_address, count, unit) -> dict[int, int]:
+        data = await self.client.read_input_registers(start_address, count=count, device_id=unit)
         registers = {c: v for c, v in enumerate(data.registers, start_address)}
         return registers
 
@@ -262,7 +262,7 @@ class GrowattDevice:
         self.holding_register = self.device_registers.holding
         self.input_register = self.device_registers.input
 
-        self.slave = unit
+        self.unit = unit
 
     async def connect(self):
         await self.modbus.connect()
@@ -274,10 +274,10 @@ class GrowattDevice:
         self.modbus.close()
 
     async def get_device_info(self) -> GrowattDeviceInfo:
-        return await self.modbus.get_device_info(self.holding_register, self.max_length, self.slave)
+        return await self.modbus.get_device_info(self.holding_register, self.max_length, self.unit)
 
     async def sync_time(self) -> timedelta:
-        device_time = await self.modbus.read_device_time(self.slave)
+        device_time = await self.modbus.read_device_time(self.unit)
         time = datetime.now()
         await self.modbus.write_device_time(
             time.year, time.month, time.day, time.hour, time.minute, time.second
@@ -307,7 +307,7 @@ class GrowattDevice:
             register_values = {}
             for item in key_sequences.holding:
                 register_values.update(
-                    await self.modbus.read_holding_registers(item[0], count=item[1], slave=self.slave)
+                    await self.modbus.read_holding_registers(item[0], count=item[1], unit=self.unit)
                 )
 
             results.update(process_registers(self.device_registers.holding, register_values))
@@ -316,7 +316,7 @@ class GrowattDevice:
             register_values = {}
             for item in key_sequences.input:
                 register_values.update(
-                    await self.modbus.read_input_registers(item[0], count=item[1], slave=self.slave)
+                    await self.modbus.read_input_registers(item[0], count=item[1], unit=self.unit)
                 )
 
             results.update(process_registers(self.device_registers.input, register_values))
@@ -324,8 +324,8 @@ class GrowattDevice:
         return results
 
     async def write_register(self, register, payload) -> ModbusPDU:
-        _LOGGER.info("Write register %d with payload %d and unit %d", register, payload, self.slave)
-        data = await self.modbus.write_register(register, payload, self.slave)
+        _LOGGER.info("Write register %d with payload %d and unit %d", register, payload, self.unit)
+        data = await self.modbus.write_register(register, payload, self.unit)
         _LOGGER.info("Write response done")
         return data
 
@@ -337,7 +337,7 @@ class GrowattDevice:
 
         for item in key_sequences:
             register_values.update(
-                await self.modbus.read_holding_registers(item[0], count=item[1], slave=self.slave)
+                await self.modbus.read_holding_registers(item[0], count=item[1], unit=self.unit)
             )
 
         results = process_registers(register, register_values)

--- a/custom_components/growatt_local/manifest.json
+++ b/custom_components/growatt_local/manifest.json
@@ -5,7 +5,7 @@
     "documentation": "https://github.com/WouterTuinstra/homeassistant-growatt-local-modbus",
     "issue_tracker": "https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus/issues",
     "dependencies": ["sun"],
-    "requirements": ["pymodbus>=3.8.3"],
+    "requirements": ["pymodbus>=3.11.1"],
     "codeowners": ["@WouterTuinstra"],
     "iot_class": "local_polling",
     "loggers": ["growattLocal"],


### PR DESCRIPTION
## Summary
- replace deprecated Modbus `unit` parameter usage with `device_id`
- require pymodbus 3.11.1+ to ensure compatibility

## Testing
- `python -m py_compile custom_components/growatt_local/API/growatt.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc5af197d88330a444863811d416ab