### PR TITLE
feat: map tl-xh bms registers

### DIFF
--- a/custom_components/growatt_local/API/device_type/base.py
+++ b/custom_components/growatt_local/API/device_type/base.py
@@ -142,6 +142,44 @@ ATTR_COMM_BOARD_TEMPERATURE = "comm_board_temperature"  # C
 ATTR_PRESENT_FFT_A = "present_fft_a"
 ATTR_INV_START_DELAY = "inv_start_delay"  # s
 
+# TL-XH BMS attributes
+ATTR_BMS_MAX_VOLT_CELL_NO = "bms_max_volt_cell_no"  # 3189
+ATTR_BMS_MIN_VOLT_CELL_NO = "bms_min_volt_cell_no"  # 3190
+ATTR_BMS_AVG_TEMP_A = "bms_avg_temp_a"  # 3191
+ATTR_BMS_MAX_CELL_TEMP_A = "bms_max_cell_temp_a"  # 3192
+ATTR_BMS_AVG_TEMP_B = "bms_avg_temp_b"  # 3193
+ATTR_BMS_MAX_CELL_TEMP_B = "bms_max_cell_temp_b"  # 3194
+ATTR_BMS_AVG_TEMP_C = "bms_avg_temp_c"  # 3195
+ATTR_BMS_MAX_SOC = "bms_max_soc"  # %, 3196
+ATTR_BMS_MIN_SOC = "bms_min_soc"  # %, 3197
+ATTR_PARALLEL_BATTERY_NUM = "parallel_battery_num"  # 3198
+ATTR_BMS_DERATE_REASON = "bms_derate_reason"  # 3199
+ATTR_BMS_GAUGE_FCC_AH = "bms_gauge_fcc_ah"  # Ah, 3200
+ATTR_BMS_GAUGE_RM_AH = "bms_gauge_rm_ah"  # Ah, 3201
+ATTR_BMS_PROTECT1 = "bms_protect1"  # 3202
+ATTR_BMS_WARN1 = "bms_warn1"  # 3203
+ATTR_BMS_FAULT1 = "bms_fault1"  # 3204
+ATTR_BMS_FAULT2 = "bms_fault2"  # 3205
+ATTR_BAT_ISO_STATUS = "bat_iso_status"  # 3210
+ATTR_BATT_REQUEST_FLAGS = "batt_request_flags"  # 3211
+ATTR_BMS_STATUS = "bms_status"  # 3212
+ATTR_BMS_PROTECT2 = "bms_protect2"  # 3213
+ATTR_BMS_WARN2 = "bms_warn2"  # 3214
+ATTR_BMS_SOC = "bms_soc"  # %, 3215
+ATTR_BMS_BATTERY_VOLTAGE = "bms_battery_voltage"  # V, 3216
+ATTR_BMS_BATTERY_CURRENT = "bms_battery_current"  # A, 3217
+ATTR_BMS_CELL_MAX_TEMP = "bms_cell_max_temp"  # 3218
+ATTR_BMS_MAX_CHARGE_CURRENT = "bms_max_charge_current"  # A, 3219
+ATTR_BMS_MAX_DISCHARGE_CURRENT = "bms_max_discharge_current"  # A, 3220
+ATTR_BMS_CYCLE_COUNT = "bms_cycle_count"  # 3221
+ATTR_BMS_SOH = "bms_soh"  # %, 3222
+ATTR_BMS_CHARGE_VOLT_LIMIT = "bms_charge_volt_limit"  # V, 3223
+ATTR_BMS_DISCHARGE_VOLT_LIMIT = "bms_discharge_volt_limit"  # V, 3224
+ATTR_BMS_WARN3 = "bms_warn3"  # 3225
+ATTR_BMS_PROTECT3 = "bms_protect3"  # 3226
+ATTR_BMS_CELL_VOLT_MAX = "bms_cell_volt_max"  # V, 3230
+ATTR_BMS_CELL_VOLT_MIN = "bms_cell_volt_min"  # V, 3231
+
 # Attribute names for values in the input register for Offgrid inverter
 ATTR_ACTIVE_POWER = "output_active_power"  # W
 

--- a/custom_components/growatt_local/API/device_type/storage_120.py
+++ b/custom_components/growatt_local/API/device_type/storage_120.py
@@ -33,6 +33,42 @@ from .base import (
     ATTR_COMM_BOARD_TEMPERATURE,
     ATTR_PRESENT_FFT_A,
     ATTR_INV_START_DELAY,
+    ATTR_BMS_MAX_VOLT_CELL_NO,
+    ATTR_BMS_MIN_VOLT_CELL_NO,
+    ATTR_BMS_AVG_TEMP_A,
+    ATTR_BMS_MAX_CELL_TEMP_A,
+    ATTR_BMS_AVG_TEMP_B,
+    ATTR_BMS_MAX_CELL_TEMP_B,
+    ATTR_BMS_AVG_TEMP_C,
+    ATTR_BMS_MAX_SOC,
+    ATTR_BMS_MIN_SOC,
+    ATTR_PARALLEL_BATTERY_NUM,
+    ATTR_BMS_DERATE_REASON,
+    ATTR_BMS_GAUGE_FCC_AH,
+    ATTR_BMS_GAUGE_RM_AH,
+    ATTR_BMS_PROTECT1,
+    ATTR_BMS_WARN1,
+    ATTR_BMS_FAULT1,
+    ATTR_BMS_FAULT2,
+    ATTR_BAT_ISO_STATUS,
+    ATTR_BATT_REQUEST_FLAGS,
+    ATTR_BMS_STATUS,
+    ATTR_BMS_PROTECT2,
+    ATTR_BMS_WARN2,
+    ATTR_BMS_SOC,
+    ATTR_BMS_BATTERY_VOLTAGE,
+    ATTR_BMS_BATTERY_CURRENT,
+    ATTR_BMS_CELL_MAX_TEMP,
+    ATTR_BMS_MAX_CHARGE_CURRENT,
+    ATTR_BMS_MAX_DISCHARGE_CURRENT,
+    ATTR_BMS_CYCLE_COUNT,
+    ATTR_BMS_SOH,
+    ATTR_BMS_CHARGE_VOLT_LIMIT,
+    ATTR_BMS_DISCHARGE_VOLT_LIMIT,
+    ATTR_BMS_WARN3,
+    ATTR_BMS_PROTECT3,
+    ATTR_BMS_CELL_VOLT_MAX,
+    ATTR_BMS_CELL_VOLT_MIN,
 )
 
 MAXIMUM_DATA_LENGTH = 100
@@ -209,6 +245,114 @@ STORAGE_INPUT_REGISTERS_120_TL_XH: tuple[GrowattDeviceRegisters, ...] = (
     ),
     GrowattDeviceRegisters(
         name=ATTR_CHARGE_ENERGY_TOTAL, register=3131, value_type=float, length=2
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_MAX_VOLT_CELL_NO, register=3189, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_MIN_VOLT_CELL_NO, register=3190, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_AVG_TEMP_A, register=3191, value_type=float
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_MAX_CELL_TEMP_A, register=3192, value_type=float
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_AVG_TEMP_B, register=3193, value_type=float
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_MAX_CELL_TEMP_B, register=3194, value_type=float
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_AVG_TEMP_C, register=3195, value_type=float
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_MAX_SOC, register=3196, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_MIN_SOC, register=3197, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_PARALLEL_BATTERY_NUM, register=3198, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_DERATE_REASON, register=3199, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_GAUGE_FCC_AH, register=3200, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_GAUGE_RM_AH, register=3201, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_PROTECT1, register=3202, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_WARN1, register=3203, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_FAULT1, register=3204, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_FAULT2, register=3205, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BAT_ISO_STATUS, register=3210, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BATT_REQUEST_FLAGS, register=3211, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_STATUS, register=3212, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_PROTECT2, register=3213, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_WARN2, register=3214, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_SOC, register=3215, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_BATTERY_VOLTAGE, register=3216, value_type=float, scale=100
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_BATTERY_CURRENT, register=3217, value_type=float, scale=100
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_CELL_MAX_TEMP, register=3218, value_type=float
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_MAX_CHARGE_CURRENT, register=3219, value_type=float, scale=100
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_MAX_DISCHARGE_CURRENT, register=3220, value_type=float, scale=100
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_CYCLE_COUNT, register=3221, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_SOH, register=3222, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_CHARGE_VOLT_LIMIT, register=3223, value_type=float, scale=100
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_DISCHARGE_VOLT_LIMIT, register=3224, value_type=float, scale=100
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_WARN3, register=3225, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_PROTECT3, register=3226, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_CELL_VOLT_MAX, register=3230, value_type=float, scale=1000
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BMS_CELL_VOLT_MIN, register=3231, value_type=float, scale=1000
     ),
 )
 


### PR DESCRIPTION
## Summary
- expose BMS register constants for TL-XH battery metrics
- map BMS telemetry registers with proper scaling in storage_120

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c47cbec7f08330b09ff3b8abe780e8