### PR TITLE
Add TL-XH battery voltage/current register mapping

### DIFF
--- a/custom_components/growatt_local/API/device_type/base.py
+++ b/custom_components/growatt_local/API/device_type/base.py
@@ -142,6 +142,14 @@ ATTR_COMM_BOARD_TEMPERATURE = "comm_board_temperature"  # C
 ATTR_PRESENT_FFT_A = "present_fft_a"
 ATTR_INV_START_DELAY = "inv_start_delay"  # s
 
+# TL-XH battery and bus attributes
+ATTR_BATTERY_VOLTAGE = "battery_voltage"  # V, 3169
+ATTR_BATTERY_CURRENT = "battery_current"  # A, 3170
+ATTR_VBUS1_VOLTAGE = "vbus1_voltage"  # V, 3172
+ATTR_VBUS2_VOLTAGE = "vbus2_voltage"  # V, 3173
+ATTR_BUCK_BOOST_CURRENT = "buck_boost_current"  # A, 3174
+ATTR_LLC_CURRENT = "llc_current"  # A, 3175
+
 # TL-XH BMS attributes
 ATTR_BMS_MAX_VOLT_CELL_NO = "bms_max_volt_cell_no"  # 3189
 ATTR_BMS_MIN_VOLT_CELL_NO = "bms_min_volt_cell_no"  # 3190
@@ -183,7 +191,6 @@ ATTR_BMS_CELL_VOLT_MIN = "bms_cell_volt_min"  # V, 3231
 # Attribute names for values in the input register for Offgrid inverter
 ATTR_ACTIVE_POWER = "output_active_power"  # W
 
-ATTR_BATTERY_VOLTAGE = "battery_voltage"  # V
 ATTR_BUS_VOLTAGE = "bus_voltage"  # V
 ATTR_OUTPUT_FREQUENCY = "output_frequency"  # Hz
 ATTR_OUTPUT_DC_VOLTAGE = "output_dc_voltage"  # V

--- a/custom_components/growatt_local/API/device_type/storage_120.py
+++ b/custom_components/growatt_local/API/device_type/storage_120.py
@@ -33,6 +33,12 @@ from .base import (
     ATTR_COMM_BOARD_TEMPERATURE,
     ATTR_PRESENT_FFT_A,
     ATTR_INV_START_DELAY,
+    ATTR_BATTERY_VOLTAGE,
+    ATTR_BATTERY_CURRENT,
+    ATTR_VBUS1_VOLTAGE,
+    ATTR_VBUS2_VOLTAGE,
+    ATTR_BUCK_BOOST_CURRENT,
+    ATTR_LLC_CURRENT,
     ATTR_BMS_MAX_VOLT_CELL_NO,
     ATTR_BMS_MIN_VOLT_CELL_NO,
     ATTR_BMS_AVG_TEMP_A,
@@ -181,12 +187,30 @@ STORAGE_INPUT_REGISTERS_120: tuple[GrowattDeviceRegisters, ...] = (
 )
 
 STORAGE_INPUT_REGISTERS_120_TL_XH: tuple[GrowattDeviceRegisters, ...] = (
+    # BDC presence flag (soms nuttig bij debugging/mapping)
+    GrowattDeviceRegisters(
+        name=ATTR_BDC_NEW_FLAG, register=3164, value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BATTERY_VOLTAGE, register=3169, value_type=float, scale=100
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BATTERY_CURRENT, register=3170, value_type=float, scale=10
+    ),
     GrowattDeviceRegisters(
         name=ATTR_SOC_PERCENTAGE, register=3171, value_type=int
     ),
-    # BDC presence flag (soms nuttig bij debugging/mapping)
     GrowattDeviceRegisters(
-        name=ATTR_BDC_NEW_FLAG,     register=3164, value_type=int
+        name=ATTR_VBUS1_VOLTAGE, register=3172, value_type=float, scale=10
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_VBUS2_VOLTAGE, register=3173, value_type=float, scale=10
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BUCK_BOOST_CURRENT, register=3174, value_type=float, scale=10
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_LLC_CURRENT, register=3175, value_type=float, scale=10
     ),
     # Batterijtemperaturen (0.1 C schaal, integration hanteert doorgaans *0.1 naar float)
     GrowattDeviceRegisters(

--- a/testing/growatt_registers.md
+++ b/testing/growatt_registers.md
@@ -611,10 +611,15 @@ Use the list below to extend tables in your device modules (copy/paste). **All r
 - `ATTR_CHARGE_ENERGY_TODAY` → **3129–3130** (kWh), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
 - `ATTR_CHARGE_ENERGY_TOTAL` → **3131–3132** (kWh), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
 
-**Candidates (confirm spec / add new attributes if missing):**
+**Implemented from spec:**
 
-- `ATTR_BATTERY_VOLTAGE` / `ATTR_BATTERY_CURRENT` around **3172–3175**, **3183–3185**
-- `ATTR_BATTERY_CYCLE_COUNT` at **3212**; charge/discharge limits around **3200–3201**
+- `ATTR_BATTERY_VOLTAGE` → **3169** (0.01 V), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
+- `ATTR_BATTERY_CURRENT` → **3170** (0.1 A), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
+- `ATTR_VBUS1_VOLTAGE` → **3172** (0.1 V), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
+- `ATTR_VBUS2_VOLTAGE` → **3173** (0.1 V), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
+- `ATTR_BUCK_BOOST_CURRENT` → **3174** (0.1 A), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
+- `ATTR_LLC_CURRENT` → **3175** (0.1 A), set: `STORAGE_INPUT_REGISTERS_120_TL_XH`
+- `ATTR_BMS_CYCLE_COUNT` → **3221** (count, spec offset from earlier 3212 note)
 - Extended hybrid block **3250–3280** (reserve until named by a newer spec)
 
 ---


### PR DESCRIPTION
## Summary
- define TL-XH battery and bus attribute constants
- map battery voltage, current and bus values in STORAGE_INPUT_REGISTERS_120_TL_XH with proper scaling
- document register positions and corrected BMS cycle count in register table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c480961d448330a48e6ed89c80ccd7