### PR TITLE
Add inverter enable switch for TL-XH storage

### DIFF
--- a/custom_components/growatt_local/API/device_type/storage_120.py
+++ b/custom_components/growatt_local/API/device_type/storage_120.py
@@ -7,6 +7,7 @@ from .base import (
     DEVICE_TYPE_CODE_REGISTER,
     NUMBER_OF_TRACKERS_AND_PHASES_REGISTER,
     ATTR_INVERTER_MODEL,
+    ATTR_INVERTER_ENABLED,
     ATTR_MODBUS_VERSION,
     ATTR_SOC_PERCENTAGE,
     ATTR_DISCHARGE_POWER,
@@ -119,6 +120,11 @@ STORAGE_HOLDING_REGISTERS_120: tuple[GrowattDeviceRegisters, ...] = (
 )
 
 STORAGE_HOLDING_REGISTERS_120_TL_XH: tuple[GrowattDeviceRegisters, ...] = (
+    GrowattDeviceRegisters(
+        name=ATTR_INVERTER_ENABLED,
+        register=0,
+        value_type=int,
+    ),
     FIRMWARE_REGISTER,
     GrowattDeviceRegisters(
         name=ATTR_INVERTER_MODEL,

--- a/custom_components/growatt_local/sensor_types/storage.py
+++ b/custom_components/growatt_local/sensor_types/storage.py
@@ -19,6 +19,7 @@ from .switch_entity_description import GrowattSwitchEntityDescription
 
 from ..API.device_type.base import (
     ATTR_AC_CHARGE_ENABLED,
+    ATTR_INVERTER_ENABLED,
     ATTR_SOC_PERCENTAGE,
     ATTR_DISCHARGE_POWER,
     ATTR_CHARGE_POWER,
@@ -88,7 +89,15 @@ STORAGE_SWITCH_TYPES: tuple[GrowattSwitchEntityDescription, ...] = (
         key=ATTR_AC_CHARGE_ENABLED,
         name="AC Charge",
         state_on=0x1,
-        state_off=0x0
+        state_off=0x0,
+    ),
+    GrowattSwitchEntityDescription(
+        key=ATTR_INVERTER_ENABLED,
+        name="Power control",
+        translation_key="inverter_enabled",
+        state_on=0x1,
+        state_off=0x0,
+        mask=0x1,
     ),
 )
 

--- a/custom_components/growatt_local/strings.json
+++ b/custom_components/growatt_local/strings.json
@@ -97,5 +97,12 @@
       "title": "Failed to migrate entity",
       "description": "**Please resolve the issue manually:**\n{error}\nYou have two options:\n1. Remove the entity with the above mentioned entityID if you want to migrate the old entity.\n2. Remove EntityID '{entity_id}' if don't want to update the entity."
     }
+  },
+  "entity": {
+    "switch": {
+      "inverter_enabled": {
+        "name": "Power control"
+      }
+    }
   }
 }

--- a/custom_components/growatt_local/switch.py
+++ b/custom_components/growatt_local/switch.py
@@ -41,13 +41,20 @@ async def async_setup_entry(
     sensor_descriptions: list[GrowattSwitchEntityDescription] = []
     supported_key_names = coordinator.growatt_api.get_register_names()
 
-    if config_entry.options.get(CONF_INVERTER_POWER_CONTROL, False):
-        sensor_descriptions.append(INVERTER_POWER_SWITCH) 
-
     for sensor in STORAGE_SWITCH_TYPES:
         if sensor.key not in supported_key_names:
             continue
         sensor_descriptions.append(sensor)
+
+    if (
+        config_entry.options.get(CONF_INVERTER_POWER_CONTROL, False)
+        and INVERTER_POWER_SWITCH.key in supported_key_names
+        and all(
+            description.key != INVERTER_POWER_SWITCH.key
+            for description in sensor_descriptions
+        )
+    ):
+        sensor_descriptions.append(INVERTER_POWER_SWITCH)
 
     coordinator.get_keys_by_name({sensor.key for sensor in sensor_descriptions}, True)
 

--- a/custom_components/growatt_local/translations/en.json
+++ b/custom_components/growatt_local/translations/en.json
@@ -97,5 +97,12 @@
       "title": "Failed to migrate entity",
       "description": "**Please resolve the issue manually:**\n{error}\nYou have two options:\n1. Remove the entity with the above mentioned entityID if you want to migrate the old entity.\n2. Remove EntityID '{entity_id}' if don't want to update the entity."
     }
+  },
+  "entity": {
+    "switch": {
+      "inverter_enabled": {
+        "name": "Power control"
+      }
+    }
   }
 }

--- a/custom_components/growatt_local/translations/nl.json
+++ b/custom_components/growatt_local/translations/nl.json
@@ -89,5 +89,12 @@
         }
       }
     }
+  },
+  "entity": {
+    "switch": {
+      "inverter_enabled": {
+        "name": "Vermogensregeling"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add GrowattSwitchEntityDescription for TL-XH inverter power control
- expose power control switch in setup when register is supported
- map TL-XH storage holding register 0 for inverter enable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c483c613d88330a9d43174b716c798