### PR TITLE
docs: document BMS registers and extend tools

### DIFF
--- a/testing/growatt_registers.md
+++ b/testing/growatt_registers.md
@@ -108,6 +108,35 @@ Mirror of 0–124, but also includes:
 | 3178–3179| Battery discharge power | W | `ATTR_DISCHARGE_POWER` |
 | 3180–3181| Battery charge power | W | `ATTR_CHARGE_POWER` |
 
+### BMS Diagnostics (3202–3231)
+| Register | Description | Unit | Attribute | Notes |
+|----------|-------------|------|-----------|-------|
+| 3202     | BMS Protect1 | - | `ATTR_BMS_PROTECT1` | |
+| 3203     | BMS Warn1 | - | `ATTR_BMS_WARN1` | |
+| 3204     | BMS Fault1 | - | `ATTR_BMS_FAULT1` | |
+| 3205     | BMS Fault2 | - | `ATTR_BMS_FAULT2` | |
+| 3210     | Battery ISO detect status | - | `ATTR_BAT_ISO_STATUS` | 0:not detected, 1:detected |
+| 3211     | Battery request flags | - | `ATTR_BATT_REQUEST_FLAGS` | |
+| 3212     | BMS status | - | `ATTR_BMS_STATUS` | |
+| 3213     | BMS Protect2 | - | `ATTR_BMS_PROTECT2` | |
+| 3214     | BMS Warn2 | - | `ATTR_BMS_WARN2` | |
+| 3215     | BMS SOC | % | `ATTR_BMS_SOC` | |
+| 3216     | BMS battery voltage | V | `ATTR_BMS_BATTERY_VOLTAGE` | ×100 |
+| 3217     | BMS battery current | A | `ATTR_BMS_BATTERY_CURRENT` | ×100 |
+| 3218     | BMS cell max temperature | °C | `ATTR_BMS_CELL_MAX_TEMP` | |
+| 3219     | BMS max charge current | A | `ATTR_BMS_MAX_CHARGE_CURRENT` | ×100 |
+| 3220     | BMS max discharge current | A | `ATTR_BMS_MAX_DISCHARGE_CURRENT` | ×100 |
+| 3221     | BMS cycle count | - | `ATTR_BMS_CYCLE_COUNT` | |
+| 3222     | BMS state of health | % | `ATTR_BMS_SOH` | |
+| 3223     | BMS charge voltage limit | V | `ATTR_BMS_CHARGE_VOLT_LIMIT` | ×100 |
+| 3224     | BMS discharge voltage limit | V | `ATTR_BMS_DISCHARGE_VOLT_LIMIT` | ×100 |
+| 3225     | BMS Warn3 | - | `ATTR_BMS_WARN3` | |
+| 3226     | BMS Protect3 | - | `ATTR_BMS_PROTECT3` | |
+| 3230     | BMS cell voltage max | V | `ATTR_BMS_CELL_VOLT_MAX` | ×1000 |
+| 3231     | BMS cell voltage min | V | `ATTR_BMS_CELL_VOLT_MIN` | ×1000 |
+
+Unknown or zeroed on hardware: 3227–3229.
+
 ### Reserved / Misc (3250–3280)
 Registers are undocumented in spec but active in scans (SOC, currents, extra power flows). Candidate mapping area for future attributes.
 

--- a/testing/input_tl_xh.json
+++ b/testing/input_tl_xh.json
@@ -1,93 +1,5 @@
 [
   {
-    "number": 3021,
-    "function_code": "04",
-    "length": 2,
-    "scale": 1,
-    "unit": "Var",
-    "description": "Reactive power (Qac H/L)"
-  },
-  {
-    "number": 3041,
-    "function_code": "04",
-    "length": 2,
-    "scale": 1,
-    "unit": "W",
-    "description": "Total forward power"
-  },
-  {
-    "number": 3043,
-    "function_code": "04",
-    "length": 2,
-    "scale": 1,
-    "unit": "W",
-    "description": "Total reverse power"
-  },
-  {
-    "number": 3045,
-    "function_code": "04",
-    "length": 2,
-    "scale": 1,
-    "unit": "W",
-    "description": "Total load power"
-  },
-  {
-    "number": 3067,
-    "function_code": "04",
-    "length": 2,
-    "scale": 1,
-    "unit": "kWh",
-    "description": "Today energy to user"
-  },
-  {
-    "number": 3069,
-    "function_code": "04",
-    "length": 2,
-    "scale": 1,
-    "unit": "",
-    "description": "32‑bit field (pair)"
-  },
-  {
-    "number": 3071,
-    "function_code": "04",
-    "length": 2,
-    "scale": 1,
-    "unit": "kWh",
-    "description": "Today energy to grid"
-  },
-  {
-    "number": 3073,
-    "function_code": "04",
-    "length": 2,
-    "scale": 1,
-    "unit": "kWh",
-    "description": "Total energy to grid"
-  },
-  {
-    "number": 3097,
-    "function_code": "04",
-    "length": 1,
-    "scale": 1,
-    "unit": "",
-    "description": "Communication board temperature"
-  },
-  {
-    "number": 3111,
-    "function_code": "04",
-    "length": 1,
-    "scale": 1,
-    "unit": "",
-    "description": "PresentFFTValue [CHANNEL_A]"
-  },
-  {
-    "number": 3115,
-    "function_code": "04",
-    "length": 1,
-    "scale": 1,
-    "unit": "",
-    "description": "Inverter start delay time"
-  },
-  {
     "number": 3125,
     "function_code": "04",
     "length": 2,
@@ -166,6 +78,221 @@
     "scale": 1,
     "unit": "W",
     "description": "Battery charge power"
+  },
+  {
+    "number": 3202,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "BMS Protect1"
+  },
+  {
+    "number": 3203,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "BMS Warn1"
+  },
+  {
+    "number": 3204,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "BMS Fault1"
+  },
+  {
+    "number": 3205,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "BMS Fault2"
+  },
+  {
+    "number": 3210,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "Battery ISO detect status"
+  },
+  {
+    "number": 3211,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "Battery request flags"
+  },
+  {
+    "number": 3212,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "BMS status"
+  },
+  {
+    "number": 3213,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "BMS Protect2"
+  },
+  {
+    "number": 3214,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "BMS Warn2"
+  },
+  {
+    "number": 3215,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "%",
+    "description": "BMS SOC"
+  },
+  {
+    "number": 3216,
+    "function_code": "04",
+    "length": 1,
+    "scale": 100,
+    "unit": "V",
+    "description": "BMS battery voltage"
+  },
+  {
+    "number": 3217,
+    "function_code": "04",
+    "length": 1,
+    "scale": 100,
+    "unit": "A",
+    "description": "BMS battery current"
+  },
+  {
+    "number": 3218,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "°C",
+    "description": "BMS cell max temperature"
+  },
+  {
+    "number": 3219,
+    "function_code": "04",
+    "length": 1,
+    "scale": 100,
+    "unit": "A",
+    "description": "BMS max charge current"
+  },
+  {
+    "number": 3220,
+    "function_code": "04",
+    "length": 1,
+    "scale": 100,
+    "unit": "A",
+    "description": "BMS max discharge current"
+  },
+  {
+    "number": 3221,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "BMS cycle count"
+  },
+  {
+    "number": 3222,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "%",
+    "description": "BMS state of health"
+  },
+  {
+    "number": 3223,
+    "function_code": "04",
+    "length": 1,
+    "scale": 100,
+    "unit": "V",
+    "description": "BMS charge voltage limit"
+  },
+  {
+    "number": 3224,
+    "function_code": "04",
+    "length": 1,
+    "scale": 100,
+    "unit": "V",
+    "description": "BMS discharge voltage limit"
+  },
+  {
+    "number": 3225,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "BMS Warn3"
+  },
+  {
+    "number": 3226,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "-",
+    "description": "BMS Protect3"
+  },
+  {
+    "number": 3230,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1000,
+    "unit": "V",
+    "description": "BMS cell voltage max"
+  },
+  {
+    "number": 3231,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1000,
+    "unit": "V",
+    "description": "BMS cell voltage min"
+  },
+  {
+    "number": 3069,
+    "function_code": "04",
+    "length": 2,
+    "scale": 1,
+    "unit": "",
+    "description": "32‑bit field (pair)"
+  },
+  {
+    "number": 3097,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "",
+    "description": "Communication board temperature"
+  },
+  {
+    "number": 3111,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "",
+    "description": "PresentFFTValue \\[CHANNEL_A]"
+  },
+  {
+    "number": 3115,
+    "function_code": "04",
+    "length": 1,
+    "scale": 1,
+    "unit": "",
+    "description": "Inverter start delay time"
   }
 ]
-

--- a/testing/parse_registers.py
+++ b/testing/parse_registers.py
@@ -66,10 +66,11 @@ def parse_registers(md_path: pathlib.Path):
             notes = cols[4] if len(cols) > 4 else (cols[3] if len(cols) > 3 else "")
 
             scale = 1
-            m_scale = re.search(r"×\s?(\d+)", desc) or re.search(r"×\s?(\d+)", notes)
+            m_scale = re.search(r"×\s?([\d.]+)", desc) or re.search(r"×\s?([\d.]+)", notes)
             if m_scale:
                 try:
-                    scale = int(m_scale.group(1))
+                    val = float(m_scale.group(1))
+                    scale = int(val) if val.is_integer() else val
                 except ValueError:
                     pass
 

--- a/testing/read_registers.py
+++ b/testing/read_registers.py
@@ -78,10 +78,11 @@ async def main():
     await dev.connect()
 
     ranges = [
-        (0, 124),
-        (3000, 3124),
-        (3125, 3249),
-        (3250, 3374),
+        (0, 124),                 # core input block
+        (3000, 3124),             # mirror of low range
+        (3125, 3199),             # battery energy counters
+        (3200, 3231),             # BMS diagnostics
+        (3232, 3374),             # remaining TL-XH block / reserved
     ]
     reg_map = dev.input_register
 


### PR DESCRIPTION
## Summary
- document BMS diagnostic registers and scaling in testing docs
- parse decimal scaling factors and regenerate input register JSON
- expand test reader to scan BMS range and reserved blocks

## Testing
- `python testing/parse_registers.py`
- `python testing/read_registers.py` *(fails: USB port /dev/ttyUSB0 is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68c4910a4aa08330aa8f6505b53b2918