### PR TITLE
Add VS Code devcontainer for development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/home-assistant/devcontainer:stable
+
+# Install development dependencies
+RUN pip install --no-cache-dir \
+    pymodbus \
+    pytest \
+    pytest-homeassistant-custom-component

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "Homeassistant Growatt Local Modbus",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "pip install -r requirements_dev.txt",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "workspaceFolder": "/workspace"
+}

--- a/README.md
+++ b/README.md
@@ -117,3 +117,16 @@ result = await growatt.update(RegisterKeys(
 
 - Make sure your user has permission to access the serial port.
 - For TCP/UDP, use `GrowattTCP` or `GrowattUDP` instead of `GrowattSerial`.
+## Development
+
+This project includes a VS Code Dev Container configuration.
+
+1. Install [Visual Studio Code](https://code.visualstudio.com/) and the Dev Containers extension.
+2. Open this repository in VS Code and choose **Reopen in Container** when prompted.
+3. After the container builds, dependencies from `requirements_dev.txt` are installed automatically.
+4. Run the tests inside the container:
+
+```bash
+pytest
+```
+

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,3 @@
+pymodbus
+pytest
+pytest-homeassistant-custom-component


### PR DESCRIPTION
## Summary
- add devcontainer Dockerfile based on Home Assistant image
- configure devcontainer.json to install requirements and mount repo
- document devcontainer usage and add development requirements file

## Testing
- `pip install -r requirements_dev.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c548a636b88330be8c17b38279c7d6