### PR TITLE
Add initial test suite and pytest configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This project includes a VS Code Dev Container configuration.
 1. Install [Visual Studio Code](https://code.visualstudio.com/) and the Dev Containers extension.
 2. Open this repository in VS Code and choose **Reopen in Container** when prompted.
 3. After the container builds, dependencies from `requirements_dev.txt` are installed automatically.
-4. Run the tests inside the container:
+4. Run the tests inside the container by executing `pytest` in the project root:
 
 ```bash
 pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+import pytest
+from datetime import timedelta
+
+from custom_components.growatt_local import GrowattLocalCoordinator
+from custom_components.growatt_local.API.const import DeviceTypes
+from custom_components.growatt_local.API.utils import RegisterKeys
+
+
+@pytest.fixture
+def hass_instance(hass):
+    """Return Home Assistant instance for tests."""
+    return hass
+
+
+class MockGrowattDevice:
+    device = DeviceTypes.INVERTER_120
+
+    async def connect(self):
+        return None
+
+    async def update(self, keys):
+        return {"input_power": 0}
+
+    def status(self, data):
+        return "online"
+
+    def get_register_names(self):
+        return {"input_power"}
+
+    def get_keys_by_name(self, names):
+        return RegisterKeys()
+
+
+@pytest.fixture
+def mock_growatt_device():
+    """Return a mocked Growatt device."""
+    return MockGrowattDevice()
+
+
+@pytest.fixture
+def coordinator(hass, mock_growatt_device):
+    """Coordinator using the mocked device."""
+    return GrowattLocalCoordinator(hass, mock_growatt_device, timedelta(seconds=60))
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable custom integrations loaded from this repository."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def expected_lingering_timers():
+    """Allow lingering timers during shutdown."""
+    return True

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,99 @@
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_IP_ADDRESS,
+    CONF_PORT,
+    CONF_ADDRESS,
+    CONF_NAME,
+    CONF_MODEL,
+    CONF_TYPE,
+    CONF_SCAN_INTERVAL,
+)
+
+from custom_components.growatt_local.const import (
+    CONF_LAYER,
+    CONF_TCP,
+    CONF_FRAME,
+    CONF_DC_STRING,
+    CONF_AC_PHASES,
+    CONF_POWER_SCAN_ENABLED,
+    CONF_POWER_SCAN_INTERVAL,
+    CONF_INVERTER_POWER_CONTROL,
+    CONF_SERIAL_NUMBER,
+    DOMAIN,
+)
+from custom_components.growatt_local.API.const import DeviceTypes
+from custom_components.growatt_local.API.device_type.base import GrowattDeviceInfo
+
+
+async def test_user_step_form(hass):
+    """Test that the initial form is served."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+
+async def test_network_flow_creates_entry(hass):
+    """Test completing the network config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_LAYER: CONF_TCP}
+    )
+
+    device_info = GrowattDeviceInfo(
+        serial_number="abc123",
+        model="Model",
+        firmware="1.0",
+        mppt_trackers=1,
+        grid_phases=1,
+        modbus_version=1.0,
+        device_type=DeviceTypes.INVERTER_120,
+    )
+
+    mock_network = AsyncMock()
+    mock_network.connect.return_value = None
+    mock_network.connected.return_value = True
+    mock_network.close.return_value = None
+
+    with patch(
+        "custom_components.growatt_local.config_flow.GrowattNetwork",
+        return_value=mock_network,
+    ), patch(
+        "custom_components.growatt_local.config_flow.get_device_info",
+        return_value=device_info,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_IP_ADDRESS: "1.2.3.4",
+                CONF_PORT: 502,
+                CONF_ADDRESS: 1,
+                CONF_FRAME: "socket",
+            },
+        )
+        assert result["type"] == "form"
+        assert result["step_id"] == "device"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_NAME: "Growatt",
+                CONF_MODEL: "Model",
+                CONF_TYPE: DeviceTypes.INVERTER_120,
+                CONF_DC_STRING: 1,
+                CONF_AC_PHASES: 1,
+                CONF_SCAN_INTERVAL: 60,
+                CONF_POWER_SCAN_ENABLED: False,
+                CONF_POWER_SCAN_INTERVAL: 5,
+                CONF_INVERTER_POWER_CONTROL: False,
+            },
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_SERIAL_NUMBER] == "abc123"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,55 @@
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_MODEL,
+    CONF_TYPE,
+    CONF_SCAN_INTERVAL,
+)
+
+from custom_components.growatt_local.const import (
+    CONF_SERIAL_NUMBER,
+    CONF_FIRMWARE,
+    CONF_DC_STRING,
+    CONF_AC_PHASES,
+    CONF_POWER_SCAN_ENABLED,
+    CONF_POWER_SCAN_INTERVAL,
+    CONF_INVERTER_POWER_CONTROL,
+    DOMAIN,
+)
+from custom_components.growatt_local.API.const import DeviceTypes
+from custom_components.growatt_local import sensor
+
+
+async def test_sensor_setup(hass, coordinator):
+    """Test setting up the sensor platform."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SERIAL_NUMBER: "abc123",
+            CONF_MODEL: "Model",
+            CONF_TYPE: DeviceTypes.INVERTER_120,
+            CONF_DC_STRING: 1,
+            CONF_AC_PHASES: 1,
+            CONF_FIRMWARE: "1.0",
+        },
+        options={
+            CONF_NAME: "Growatt",
+            CONF_SCAN_INTERVAL: 60,
+            CONF_POWER_SCAN_ENABLED: False,
+            CONF_POWER_SCAN_INTERVAL: 5,
+            CONF_INVERTER_POWER_CONTROL: False,
+        },
+    )
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})["abc123"] = coordinator
+
+    entities = []
+
+    def async_add_entities(new_entities, update_before_add=False):
+        entities.extend(new_entities)
+
+    await sensor.async_setup_entry(hass, entry, async_add_entities)
+
+    assert entities
+    assert entities[0].entity_description.key == "input_power"


### PR DESCRIPTION
## Summary
- add pytest configuration and test scaffolding
- cover config flow and sensor setup with initial tests
- document running tests in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c54a1373848330bbbff2881c8f59bb