### PR TITLE
Add Modbus simulator and fixture-based tests

### DIFF
--- a/testing/modbus_simulator.py
+++ b/testing/modbus_simulator.py
@@ -1,0 +1,55 @@
+import asyncio
+import contextlib
+import json
+from pathlib import Path
+from contextlib import asynccontextmanager
+
+from pymodbus.datastore import ModbusServerContext, ModbusDeviceContext, ModbusSequentialDataBlock
+from pymodbus.server import ModbusTcpServer
+
+BASE_PATH = Path(__file__).parent
+
+
+def _load_registers(filename: str) -> dict[int, int]:
+    with open(BASE_PATH / filename, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    registers: dict[int, int] = {}
+    for item in data:
+        number = int(item["number"])
+        length = int(item.get("length", 1))
+        for offset in range(length):
+            registers[number + offset] = number + offset
+    return registers
+
+
+@asynccontextmanager
+async def start_simulator(port: int = 5020):
+    """Start a Modbus TCP simulator serving predefined registers."""
+    holding = _load_registers("holding_min.json")
+    input_ = _load_registers("input_min.json")
+
+    max_hr = max(holding.keys(), default=0)
+    max_ir = max(input_.keys(), default=0)
+
+    hr_values = [0] * (max_hr + 1)
+    ir_values = [0] * (max_ir + 1)
+    for addr, val in holding.items():
+        hr_values[addr] = val
+    for addr, val in input_.items():
+        ir_values[addr] = val
+
+    store = ModbusDeviceContext(
+        hr=ModbusSequentialDataBlock(0, hr_values),
+        ir=ModbusSequentialDataBlock(0, ir_values),
+    )
+    context = ModbusServerContext(store, single=True)
+
+    server = ModbusTcpServer(context, address=("localhost", port))
+    task = asyncio.create_task(server.serve_forever())
+    try:
+        yield ("localhost", port)
+    finally:
+        await server.shutdown()
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.const import (
@@ -21,8 +22,10 @@ from custom_components.growatt_local.API.const import DeviceTypes
 from custom_components.growatt_local import sensor
 
 
+pytestmark = pytest.mark.enable_socket
+
+
 async def test_sensor_setup(hass, coordinator):
-    """Test setting up the sensor platform."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -50,6 +53,8 @@ async def test_sensor_setup(hass, coordinator):
         entities.extend(new_entities)
 
     await sensor.async_setup_entry(hass, entry, async_add_entities)
+    await coordinator.async_request_refresh()
 
     assert entities
     assert entities[0].entity_description.key == "input_power"
+    assert coordinator.data["input_power"] == (1 << 16) | 2


### PR DESCRIPTION
## Summary
- add a pymodbus-based simulator that serves holding and input registers
- start simulator in tests via fixture and use deterministic registers
- exercise sensor setup against the simulator

## Testing
- `pytest` *(fails: A test tried to use socket.socket)*

------
https://chatgpt.com/codex/tasks/task_e_68c5610291b483309f44d2495581e3c5