### PR TITLE
Add CI workflow for tests and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements_dev.txt
+      - name: Install dependencies
+        run: |
+          pip install -r requirements_dev.txt
+          pip install ruff
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest --cov=custom_components/growatt_local


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint with ruff and run pytest with coverage

## Testing
- `ruff check .` *(fails: unused imports, extraneous f-strings, type comparison issues)*
- `pytest --cov=custom_components/growatt_local` *(fails: ModuleNotFoundError: No module named 'homeassistant.util')*

------
https://chatgpt.com/codex/tasks/task_e_68c56ae3c84c8330abc68939ef8a1248