### PR TITLE
docs: document dev container and simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,30 @@ git clone https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus.g
 ln -s /share/custom_components/Homeassistant-Growatt-Local-Modbus/custom_components/growatt_local /config/custom_components/growatt_local
 ```
 
+## Development
+
+This project ships with a VS Code Dev Container configuration.
+
+1. Install [Visual Studio Code](https://code.visualstudio.com/) and the Dev Containers extension.
+2. Open this repository in VS Code and choose **Reopen in Container** when prompted.
+3. After the container finishes building, dependencies from `requirements_dev.txt` are installed.
+
+Run the tests from inside the container:
+
+```bash
+pytest
+```
+
+To run the integration without hardware, start the Modbus simulator and probe a few registers:
+
+```bash
+python testing/probe_simulator.py
+```
+
+The simulator serves a static register dataset, enabling dry runs before connecting to real devices.
+
+For advanced register parsing and debugging utilities, see the files in the [`testing`](testing) directory.
+
 # Example: Testing the API and Requesting Register Values Without Home Assistant
 
 You can test the API directly without Home Assistant by running a Python script. This is useful for development, debugging, or exploring register values.
@@ -117,16 +141,3 @@ result = await growatt.update(RegisterKeys(
 
 - Make sure your user has permission to access the serial port.
 - For TCP/UDP, use `GrowattTCP` or `GrowattUDP` instead of `GrowattSerial`.
-## Development
-
-This project includes a VS Code Dev Container configuration.
-
-1. Install [Visual Studio Code](https://code.visualstudio.com/) and the Dev Containers extension.
-2. Open this repository in VS Code and choose **Reopen in Container** when prompted.
-3. After the container builds, dependencies from `requirements_dev.txt` are installed automatically.
-4. Run the tests inside the container by executing `pytest` in the project root:
-
-```bash
-pytest
-```
-

--- a/testing/modbus_simulator.py
+++ b/testing/modbus_simulator.py
@@ -44,10 +44,11 @@ async def start_simulator(port: int = 5020):
     )
     context = ModbusServerContext(store, single=True)
 
-    server = ModbusTcpServer(context, address=("localhost", port))
+    server = ModbusTcpServer(context, address=("127.0.0.1", port))
     task = asyncio.create_task(server.serve_forever())
+    await asyncio.sleep(0.1)
     try:
-        yield ("localhost", port)
+        yield ("127.0.0.1", port)
     finally:
         await server.shutdown()
         task.cancel()

--- a/testing/probe_simulator.py
+++ b/testing/probe_simulator.py
@@ -1,7 +1,7 @@
 """Small probe utility to read a few registers from the simulator.
 
 Usage:
-  python testing/probe_simulator.py --port 5034 --device min_6000xh_tl --dataset min_6000xh_tl_scan3.json
+  python testing/probe_simulator.py --port 5034
 """
 from __future__ import annotations
 
@@ -22,14 +22,12 @@ from testing.modbus_simulator import start_simulator  # type: ignore
 def parse_args():
     p = argparse.ArgumentParser()
     p.add_argument('--port', type=int, default=5034)
-    p.add_argument('--device', default='min_6000xh_tl')
-    p.add_argument('--dataset', default='min_6000xh_tl_scan3.json')
     return p.parse_args()
 
 
 async def run():
     args = parse_args()
-    async with start_simulator(port=args.port, device=args.device, dataset=args.dataset):
+    async with start_simulator(port=args.port):
         client = AsyncModbusTcpClient('localhost', port=args.port)
         await client.connect()
         for base, count, label in [(30, 10, 'holding'), (331, 2, 'holding'), (92, 6, 'input')]:


### PR DESCRIPTION
## Summary
- add Development section covering VS Code dev container, running pytest, and using Modbus simulator
- clarify probe simulator usage
- make Modbus simulator bind to 127.0.0.1

## Testing
- `python testing/probe_simulator.py`
- `pytest` *(fails: KeyError: 'input_power')*


------
https://chatgpt.com/codex/tasks/task_e_68c56c460a2483309feef8959f2dcb87