### PR TITLE
Use HTTPS for growatt-rtu-broker submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external/growatt-rtu-broker"]
 	path = external/growatt-rtu-broker
-	url = git@github.com:l4m4re/growatt-rtu-broker.git
+	url = https://github.com/l4m4re/growatt-rtu-broker.git
 	branch = main


### PR DESCRIPTION
## Summary
- switch submodule to HTTPS
- ensure growatt-rtu-broker submodule fetched

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c57de7e584833084c38e87dbf233b2