### PR TITLE
Document register ranges for all inverter types

### DIFF
--- a/custom_components/growatt_local/API/device_type/inverter_120.py
+++ b/custom_components/growatt_local/API/device_type/inverter_120.py
@@ -1,4 +1,9 @@
-"""Device defaults for a Growatt Inverter."""
+"""Device defaults for TL-X/TL-XH (MIN) inverters.
+
+Per Growatt Modbus protocol v1.24 the register ranges are:
+- FC03: ``0–124`` and ``3000–3124`` (``3125–3249`` for TL-XH US)
+- FC04: ``3000–3124``, ``3125–3249`` and ``3250–3374`` (TL-XH)
+"""
 
 from .base import (
     GrowattDeviceRegisters,

--- a/custom_components/growatt_local/API/device_type/inverter_315.py
+++ b/custom_components/growatt_local/API/device_type/inverter_315.py
@@ -1,4 +1,9 @@
-"""Device defaults for a Growatt Inverter."""
+"""Device defaults for TL3-X/MAX/MID/MAC inverters.
+
+Per Growatt Modbus protocol v1.24 the register ranges are:
+- FC03: ``0–124`` and ``125–249``
+- FC04: ``0–124`` and ``125–249``
+"""
 
 from .base import (
     GrowattDeviceRegisters,

--- a/custom_components/growatt_local/API/device_type/offgrid.py
+++ b/custom_components/growatt_local/API/device_type/offgrid.py
@@ -1,4 +1,9 @@
-"""Device defaults for a Growatt Offgrid Inverter SPF."""
+"""Device defaults for a Growatt Offgrid (SPF) inverter.
+
+Register offsets for these units are vendor-specific and not covered in the
+main Modbus protocol document. ``INPUT_REGISTERS_OFFGRID`` below captures the
+observed mapping starting at address ``0``.
+"""
 
 from enum import Enum
 from typing import Any

--- a/custom_components/growatt_local/API/device_type/storage_120.py
+++ b/custom_components/growatt_local/API/device_type/storage_120.py
@@ -1,4 +1,12 @@
-"""Device defaults for a Growatt Inverter."""
+"""Register mappings for storage inverters (MIX/SPA/SPH).
+
+Per Growatt Modbus protocol v1.24 the base ranges are:
+- FC03: ``0–124`` and ``1000–1124``
+- FC04: ``0–124`` and ``1000–1124`` (``1125–1249`` plus ``2000–2124`` for SPA)
+
+TL-XH models mirror these registers in the ``3000+`` range which is mapped
+below.
+"""
 
 from .base import (
     GrowattDeviceRegisters,

--- a/testing/growatt_registers.md
+++ b/testing/growatt_registers.md
@@ -6,6 +6,21 @@ Registers are clearly split between **Holding Registers (FC=03/06/16)** and **In
 
 ---
 
+## Supported inverter types
+
+The protocol defines different register ranges for each inverter family. The
+table below summarises the ranges from the vendor specification and points to
+the API modules that implement the mapping.
+
+| Inverter family | FC03 ranges | FC04 ranges | API module |
+|-----------------|-------------|-------------|------------|
+| TL-X/TL-XH/TL-XH US (MIN) | 0–124, 3000–3124 (3125–3249 TL-XH US) | 3000–3124, 3125–3249, 3250–3374 (TL-XH) | `device_type/inverter_120.py`, `device_type/storage_120.py` |
+| TL3-X/MAX/MID/MAC | 0–124, 125–249 | 0–124, 125–249 | `device_type/inverter_315.py` |
+| Storage (MIX/SPA/SPH) | 0–124, 1000–1124 | 0–124, 1000–1124 (1125–1249; 2000–2124 for SPA) | `device_type/storage_120.py` |
+| Offgrid (SPF) | vendor-specific | vendor-specific | `device_type/offgrid.py` |
+
+---
+
 ## 📖 Function Codes
 - **Input Registers (Read-only)** – Function code 04
 - **Holding Registers (Read/Write)** – Function codes 03 (read), 06 (write single), 16 (write multiple)


### PR DESCRIPTION
## Summary
- Document Modbus register ranges for all supported inverter families in `growatt_registers.md`
- Add protocol references to inverter mapping modules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c59d1aab5883308e48f38fe97dd6f8