### PR TITLE
Improve Modbus simulator debug logging and add register read test

### DIFF
--- a/tests/test_simulator_register_reads.py
+++ b/tests/test_simulator_register_reads.py
@@ -1,14 +1,14 @@
-"""
-Test that the simulator responds correctly to pymodbus read requests for holding registers using GrowattNetwork.
-Validates that values read match those in the min_6000xh_tl dataset.
-"""
+"""Test Modbus simulator register reads."""
 
 import asyncio
 import json
 from pathlib import Path
 
 import pytest
-from pymodbus.client import ModbusTcpClient
+from pymodbus.client import AsyncModbusTcpClient
+from pymodbus.framer import FramerType
+
+pytestmark = pytest.mark.enable_socket
 
 DATASET_PATH = (
     Path(__file__).parent.parent / "testing" / "datasets" / "min_6000xh_tl.json"
@@ -17,30 +17,33 @@ UNIT_ID = 1
 
 
 @pytest.mark.asyncio
-async def test_simulator_register_reads(modbus_simulator):
+async def test_simulator_register_reads():
+    from testing.modbus_simulator import start_simulator
+    import socket
+
+    # Find free port
+    s = socket.socket(); s.bind(("127.0.0.1", 0)); port = s.getsockname()[1]; s.close()
+
     # Load expected values from dataset
     with DATASET_PATH.open("r", encoding="utf-8") as f:
         dataset = json.load(f)
     expected = {int(k): int(v) for k, v in dataset["holding"].items()}
 
-    # Connect to simulator
-    # Verify a representative register from the dataset to confirm simulator wiring
     address, value = next(iter(expected.items()))
 
-    def _read_register():
-        import pytest_socket
-
-        pytest_socket.enable_socket()
-        client = ModbusTcpClient(
-            modbus_simulator["host"], port=modbus_simulator["port"]
+    async with start_simulator(port=port, debug_wire=True) as (host, real_port):
+        client = AsyncModbusTcpClient(
+            host,
+            port=real_port,
+            framer=FramerType.SOCKET,
+            reconnect_delay=0,
         )
-        client.connect()
+        await client.connect()
+        await asyncio.sleep(0.05)
         try:
-            return client.read_holding_registers(address - 1, count=1, device_id=1)
+            rr = await client.read_holding_registers(address - 1, count=1, device_id=1)
         finally:
             client.close()
-
-    rr = await asyncio.to_thread(_read_register)
     assert not rr.isError(), f"Read error at address {address}"
     read_val = rr.registers[0]
     assert read_val == value, (


### PR DESCRIPTION
## Summary
- add optional wire-level debug logging to Modbus simulator
- verify holding register reads against dataset via a new async test

## Testing
- `pytest tests/test_modbus_simulator.py -q`
- `pytest tests/test_simulator_register_reads.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6bf8fdfec83309d0014d6972b7a39