### PR TITLE
Fix Modbus simulator addressing and dataset value handling

### DIFF
--- a/DEBUG_REPORT.md
+++ b/DEBUG_REPORT.md
@@ -59,3 +59,13 @@
 - Document findings and changes in this file.
 - Ensure all register reads succeed and values match expectations.
 - Leave detailed logs and comments for future debugging.
+
+## Updates
+
+- Corrected simulator address base for holding registers (start at 1) to resolve
+  off-by-one reads where address `2` returned the value for register `3`.
+- Normalized dataset loading to store 16-bit unsigned values ensuring negative
+  register data does not break responses.
+- Adjusted tests to mask dataset values to 16 bits and to chunk large block
+  reads within the Modbus limit of 125 registers.
+- All tests now pass, and sequential register reads complete without connection loss.


### PR DESCRIPTION
## Summary
- align holding register base address with pymodbus TCP offset
- load dataset values as unsigned 16-bit and provide deterministic input registers
- mask dataset values and chunk large block reads in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6d6bcc2188330a15ad1df60a735d2