### PR TITLE
Handle Growatt write payloads without display aliases

### DIFF
--- a/custom_components/growatt_local/API/device_type/inverter_120.py
+++ b/custom_components/growatt_local/API/device_type/inverter_120.py
@@ -115,7 +115,7 @@ HOLDING_REGISTERS_120: tuple[GrowattDeviceRegisters, ...] = (
     GrowattDeviceRegisters(
         name=ATTR_INVERTER_ENABLED,
         register=0,
-        value_type=int
+        value_type=int,
     ),
     FIRMWARE_REGISTER,
     SERIAL_NUMBER_REGISTER,

--- a/custom_components/growatt_local/API/device_type/inverter_315.py
+++ b/custom_components/growatt_local/API/device_type/inverter_315.py
@@ -76,7 +76,7 @@ HOLDING_REGISTERS_315: tuple[GrowattDeviceRegisters, ...] = (
     GrowattDeviceRegisters(
         name=ATTR_INVERTER_ENABLED,
         register=0,
-        value_type=int
+        value_type=int,
     ),
     FIRMWARE_REGISTER,
     SERIAL_NUMBER_REGISTER,

--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -144,9 +144,15 @@ class GrowattModbusBase:
         await self.client.write_register(49, minute)
         await self.client.write_register(50, second)
 
-    async def write_register(self, register, value, slave) -> ModbusPDU:  
-        payload = ModbusBaseClient.convert_to_registers(value, ModbusBaseClient.DATATYPE.INT16)
-        return await self.client.write_register(register, payload[0], slave=slave)
+    async def write_register(
+        self, register: int, value: int | Sequence[int], slave: int
+    ) -> ModbusPDU:
+        payload = ModbusBaseClient.convert_to_registers(
+            value, ModbusBaseClient.DATATYPE.INT16
+        )
+        return await self.client.write_register(
+            register, payload[0], device_id=slave
+        )
 
     async def read_holding_registers(self, start_address, count, slave) -> dict[int, int]:
         data = await self.client.read_holding_registers(start_address, count=count, device_id=slave)
@@ -328,8 +334,15 @@ class GrowattDevice:
 
         return results
 
-    async def write_register(self, register, payload) -> ModbusPDU:
-        _LOGGER.info("Write register %d with payload %d and unit %d", register, payload, self.slave)
+    async def write_register(
+        self, register: int, payload: int | Sequence[int]
+    ) -> ModbusPDU:
+        _LOGGER.info(
+            "Write register %s with payload %s and unit %s",
+            register,
+            payload,
+            self.slave,
+        )
         data = await self.modbus.write_register(register, payload, self.slave)
         _LOGGER.info("Write response done")
         return data

--- a/tests/test_growatt_api_read_write.py
+++ b/tests/test_growatt_api_read_write.py
@@ -31,6 +31,9 @@ def ensure_pkg(name: str, path: Path):
 ensure_pkg("custom_components", CC_DIR)
 ensure_pkg("custom_components.growatt_local", GL_DIR)
 ensure_pkg("custom_components.growatt_local.API", API_DIR)
+ensure_pkg(
+    "custom_components.growatt_local.API.device_type", API_DIR / "device_type"
+)
 
 
 def import_api(name: str):
@@ -47,6 +50,7 @@ def import_api(name: str):
 
 growatt = import_api("growatt")
 utils = import_api("utils")
+from custom_components.growatt_local.API.device_type.base import ATTR_INVERTER_ENABLED
 
 
 import socket
@@ -79,7 +83,7 @@ async def test_growatt_api_read_write():
         # Read initial value
         keys = utils.RegisterKeys(holding={reg_addr})
         result = await device.update(keys)
-        initial = result.get("Remote On/Off", None)
+        initial = result.get(ATTR_INVERTER_ENABLED, None)
         # Write a new value (toggle)
         new_val = 1 if initial == 0 else 0
         # Try writing using the API
@@ -89,7 +93,7 @@ async def test_growatt_api_read_write():
             pytest.fail(f"TypeError in write_register: {e}")
         # Read back and verify
         result2 = await device.update(keys)
-        after = result2.get("Remote On/Off", None)
+        after = result2.get(ATTR_INVERTER_ENABLED, None)
         assert after == new_val, f"Write did not persist: wrote {new_val}, got {after}"
         # Try writing with extra kwargs to catch argument errors
         with pytest.raises(TypeError):


### PR DESCRIPTION
## Summary
- allow the Growatt API write_register helper to accept list payloads, log them safely, and pass the device id when issuing writes
- remove the register display_name aliasing and rely on existing ATTR_ names, updating the read/write regression test accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c842e9a374833083fb5d048e4fbfa6