### PR TITLE
Add Modbus serial simulator support and tests

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,5 @@ pytest-homeassistant-custom-component
 homeassistant
 hassil
 mutagen
+pyserial
+pyserial-asyncio

--- a/scripts/start-serial-simulator.sh
+++ b/scripts/start-serial-simulator.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+if ! command -v socat >/dev/null 2>&1; then
+  echo "Error: socat is required to create pseudo-terminals" >&2
+  exit 1
+fi
+
+TMP_LOG=$(mktemp)
+SOCAT_PID=""
+SIM_PID=""
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  if [[ -n "${SIM_PID}" ]]; then
+    kill "${SIM_PID}" 2>/dev/null || true
+  fi
+  if [[ -n "${SOCAT_PID}" ]]; then
+    kill "${SOCAT_PID}" 2>/dev/null || true
+  fi
+  rm -f "${TMP_LOG}"
+  exit ${status}
+}
+trap cleanup EXIT INT TERM
+
+socat -d -d PTY,raw,echo=0 PTY,raw,echo=0 2>"${TMP_LOG}" &
+SOCAT_PID=$!
+
+# Wait for socat to report both PTY device paths
+while [[ $(grep -c 'PTY is' "${TMP_LOG}") -lt 2 ]]; do
+  if ! kill -0 "${SOCAT_PID}" 2>/dev/null; then
+    cat "${TMP_LOG}" >&2 || true
+    echo "Failed to create pseudo terminals" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+mapfile -t PORTS < <(awk '/PTY is/ {print $NF}' "${TMP_LOG}")
+if [[ ${#PORTS[@]} -lt 2 ]]; then
+  echo "Unable to determine pseudo terminal paths" >&2
+  exit 1
+fi
+SIM_PORT="${PORTS[0]}"
+CLIENT_PORT="${PORTS[1]}"
+
+echo "Simulator serial port: ${SIM_PORT}" >&2
+echo "Client serial port: ${CLIENT_PORT}" >&2
+# Print the client-facing port so callers can capture it easily
+printf '%s\n' "${CLIENT_PORT}"
+
+PYTHON_BIN=${PYTHON:-python}
+"${PYTHON_BIN}" "${REPO_ROOT}/testing/modbus_simulator.py" --mode serial --serial-port "${SIM_PORT}" "$@" &
+SIM_PID=$!
+
+wait "${SIM_PID}"

--- a/tests/serial_helpers.py
+++ b/tests/serial_helpers.py
@@ -1,0 +1,46 @@
+"""Helpers for setting up virtual serial links using socat."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Tuple
+
+__all__ = ["virtual_serial_pair"]
+
+
+@asynccontextmanager
+async def virtual_serial_pair() -> AsyncIterator[Tuple[str, str]]:
+    """Create a connected PTY pair backed by a socat process."""
+    try:
+        process = await asyncio.create_subprocess_exec(
+            "socat",
+            "-d",
+            "-d",
+            "PTY,raw,echo=0",
+            "PTY,raw,echo=0",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - environment issue
+        raise RuntimeError("socat is required for serial tests") from exc
+
+    ports: list[str] = []
+    assert process.stderr is not None
+
+    try:
+        while len(ports) < 2:
+            line = await process.stderr.readline()
+            if not line:
+                raise RuntimeError("Failed to start socat PTY pair")
+            text = line.decode().strip()
+            if "PTY is" in text:
+                ports.append(text.split()[-1])
+        # socat prints a final status line before entering transfer loop; consume it
+        await asyncio.sleep(0)
+        yield ports[0], ports[1]
+    finally:
+        process.terminate()
+        with contextlib.suppress(ProcessLookupError):
+            await process.wait()

--- a/tests/test_growatt_api_read_write.py
+++ b/tests/test_growatt_api_read_write.py
@@ -55,6 +55,7 @@ from custom_components.growatt_local.API.device_type.base import ATTR_INVERTER_E
 
 import socket
 from testing.modbus_simulator import start_simulator
+from .serial_helpers import virtual_serial_pair
 
 
 @pytest.mark.asyncio
@@ -100,3 +101,44 @@ async def test_growatt_api_read_write():
             await device.write_register(reg_addr, [new_val], slave=1)
         # Clean up
         device.close()
+
+
+@pytest.mark.asyncio
+async def test_growatt_api_read_write_serial():
+    async with virtual_serial_pair() as (sim_port, client_port):
+        async with start_simulator(
+            mode="serial",
+            serial_port=sim_port,
+            force_deterministic=True,
+        ):
+            modbus = growatt.GrowattSerial(
+                client_port,
+                baudrate=9600,
+                stopbits=1,
+                parity="N",
+                bytesize=8,
+                timeout=1,
+            )
+            device = growatt.GrowattDevice(
+                modbus,
+                growatt.DeviceTypes.HYBRID_120_TL_XH,
+                1,
+            )
+            await device.connect()
+            reg_addr = 0
+            keys = utils.RegisterKeys(holding={reg_addr})
+            result = await device.update(keys)
+            initial = result.get(ATTR_INVERTER_ENABLED, None)
+            new_val = 1 if initial == 0 else 0
+            try:
+                await device.write_register(reg_addr, [new_val])
+            except TypeError as e:
+                pytest.fail(f"TypeError in write_register: {e}")
+            result2 = await device.update(keys)
+            after = result2.get(ATTR_INVERTER_ENABLED, None)
+            assert after == new_val, (
+                f"Write did not persist: wrote {new_val}, got {after}"
+            )
+            with pytest.raises(TypeError):
+                await device.write_register(reg_addr, [new_val], slave=1)
+            device.close()


### PR DESCRIPTION
## Summary
- extend the Modbus simulator to support RTU endpoints and expose serial CLI options
- add a socat-based helper script plus reusable virtual serial fixture for tests
- mirror existing regression coverage with serial-mode tests and include pyserial deps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c854bf72948330b3027b4428356431