### PR TITLE
Refine input register data types

### DIFF
--- a/doc/build_input_spec.py
+++ b/doc/build_input_spec.py
@@ -1,0 +1,1019 @@
+#!/usr/bin/env python3
+"""Rebuild the input register portion of growatt_registers_spec.json.
+
+The canonical data lives in `growatt_local_registers.json` and the
+home-grown metadata below.  The goal is to provide clean descriptions,
+units, and data types for the TL-X/TL-XH telemetry ranges.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import re
+from typing import Callable, Iterable
+
+DOC_DIR = Path(__file__).resolve().parent
+SPEC_PATH = DOC_DIR / "growatt_registers_spec.json"
+MAPPING_PATH = DOC_DIR / "growatt_local_registers.json"
+DATA_TYPES_PATH = DOC_DIR / "growatt_register_data_types.json"
+
+@dataclass(frozen=True)
+class RegisterMeta:
+    register: int
+    register_end: int
+    attributes: tuple[str, ...]
+    name: str
+    description: str
+    unit: str | None
+    data_type: str
+    families: tuple[str, ...]
+    access: str = "R"
+    note: str | None = None
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def tracker_description(index: int, field: str) -> tuple[str, str, str | None]:
+    label = f"PV{index}"
+    if field == "voltage":
+        return (
+            f"{label} DC voltage",
+            f"Instantaneous {label} string voltage measured at the inverter input.",
+            "V",
+        )
+    if field == "amperage":
+        return (
+            f"{label} DC current",
+            f"Instantaneous {label} string current flowing into the inverter.",
+            "A",
+        )
+    if field == "power":
+        return (
+            f"{label} DC power",
+            f"Real-time DC power from {label} computed from voltage and current readings.",
+            "W",
+        )
+    if field == "energy_today":
+        return (
+            f"{label} energy today",
+            f"Energy harvested by {label} today. Values use 0.1 kWh resolution.",
+            "kWh",
+        )
+    if field == "energy_total":
+        return (
+            f"{label} energy total",
+            f"Lifetime energy harvested by {label}. Values use 0.1 kWh resolution.",
+            "kWh",
+        )
+    raise KeyError(field)
+
+
+PHASE_NAMES = {
+    1: "phase L1",
+    2: "phase L2",
+    3: "phase L3",
+}
+
+
+def phase_description(index: int, field: str) -> tuple[str, str, str | None]:
+    phase = PHASE_NAMES.get(index, f"phase {index}")
+    if field == "voltage":
+        return (
+            f"AC {phase} voltage",
+            f"AC output voltage for {phase}.",
+            "V",
+        )
+    if field == "amperage":
+        return (
+            f"AC {phase} current",
+            f"AC output current for {phase}.",
+            "A",
+        )
+    if field == "power":
+        return (
+            f"AC {phase} power",
+            f"Active power exported on {phase}.",
+            "W",
+        )
+    raise KeyError(field)
+
+
+def energy_flow_description(flow: str) -> tuple[str, str, str | None]:
+    if flow == "power_to_user":
+        return (
+            "Load supply power",
+            "Real-time active power delivered to on-site (self-consumption) loads.",
+            "W",
+        )
+    if flow == "power_to_grid":
+        return (
+            "Grid export power",
+            "Active power exported to the utility grid.",
+            "W",
+        )
+    if flow == "power_user_load":
+        return (
+            "Home load power",
+            "Aggregate instantaneous demand from on-site loads.",
+            "W",
+        )
+    if flow == "energy_to_user_today":
+        return (
+            "Load energy today",
+            "Energy delivered to on-site loads today (0.1 kWh resolution).",
+            "kWh",
+        )
+    if flow == "energy_to_user_total":
+        return (
+            "Load energy total",
+            "Lifetime energy delivered to on-site loads (0.1 kWh resolution).",
+            "kWh",
+        )
+    if flow == "energy_to_grid_today":
+        return (
+            "Export energy today",
+            "Energy exported to the grid today (0.1 kWh resolution).",
+            "kWh",
+        )
+    if flow == "energy_to_grid_total":
+        return (
+            "Export energy total",
+            "Lifetime energy exported to the grid (0.1 kWh resolution).",
+            "kWh",
+        )
+    raise KeyError(flow)
+
+
+ATTRIBUTE_OVERRIDES: dict[str, tuple[str, str, str | None]] = {
+    "status_code": (
+        "Inverter status",
+        "Operating state reported by the inverter controller (0=waiting, 1=normal, 3=fault, 5=PV charge, 6=AC charge, 7=combined charge, 8=combined charge bypass, 9=PV charge bypass, 10=AC charge bypass, 11=bypass, 12=PV charge + discharge).",
+        None,
+    ),
+    "input_power": (
+        "PV input power",
+        "Total PV input power summed across all strings (0.1 W resolution).",
+        "W",
+    ),
+    "output_power": (
+        "AC output power",
+        "Active AC output power delivered by the inverter (0.1 W resolution).",
+        "W",
+    ),
+    "grid_frequency": (
+        "Grid frequency",
+        "Measured grid frequency with 0.01 Hz resolution.",
+        "Hz",
+    ),
+    "operation_hours": (
+        "Run time",
+        "Total cumulative run time of the inverter. Raw values are seconds scaled by 1/7200 (0.0001389 hours).",
+        "h",
+    ),
+    "input_energy_total": (
+        "PV energy total",
+        "Total PV energy generated across all strings (0.1 kWh resolution).",
+        "kWh",
+    ),
+    "output_energy_today": (
+        "Output energy today",
+        "Energy exported to the AC output today (0.1 kWh resolution).",
+        "kWh",
+    ),
+    "output_energy_total": (
+        "Output energy total",
+        "Lifetime AC output energy (0.1 kWh resolution).",
+        "kWh",
+    ),
+    "output_reactive_power": (
+        "Output reactive power",
+        "Instantaneous reactive power on the AC output (positive = inductive, negative = capacitive).",
+        "var",
+    ),
+    "output_reactive_energy_total": (
+        "Reactive energy total",
+        "Lifetime accumulated reactive energy (0.1 kvarh resolution).",
+        "kvarh",
+    ),
+    "derating_mode": (
+        "Derating mode",
+        "Active derating reason reported by the inverter controller.",
+        None,
+    ),
+    "inverter_temperature": (
+        "Inverter temperature",
+        "Main inverter heatsink temperature (0.1 °C resolution).",
+        "°C",
+    ),
+    "ipm_temperature": (
+        "IPM temperature",
+        "IPM (power module) temperature (0.1 °C resolution).",
+        "°C",
+    ),
+    "boost_temperature": (
+        "Boost temperature",
+        "Boost inductor temperature (0.1 °C resolution).",
+        "°C",
+    ),
+    "comm_board_temperature": (
+        "Communication board temperature",
+        "Temperature reported by the communication/control board (0.1 °C resolution).",
+        "°C",
+    ),
+    "p_bus_voltage": (
+        "P-bus voltage",
+        "Positive DC bus voltage (0.1 V resolution).",
+        "V",
+    ),
+    "n_bus_voltage": (
+        "N-bus voltage",
+        "Negative DC bus voltage (0.1 V resolution).",
+        "V",
+    ),
+    "real_output_power_percent": (
+        "Output power percentage",
+        "Instantaneous AC output as a percentage of the inverter's rated power.",
+        "%",
+    ),
+    "fault_code": (
+        "Fault code",
+        "Current inverter fault code (see protocol documentation).",
+        None,
+    ),
+    "warning_code": (
+        "Warning code",
+        "Current inverter warning code (vendor-defined bitmask).",
+        None,
+    ),
+    "present_fft_a": (
+        "Present FFT value (channel A)",
+        "Latest Fast Fourier Transform diagnostic value for channel A.",
+        None,
+    ),
+    "inv_start_delay": (
+        "Inverter start delay",
+        "Seconds remaining before restart once grid conditions recover.",
+        "s",
+    ),
+    "discharge_energy_today": (
+        "Battery discharge today",
+        "Energy discharged from the battery into the AC system today (0.1 kWh resolution).",
+        "kWh",
+    ),
+    "discharge_energy_total": (
+        "Battery discharge total",
+        "Total energy discharged from the battery (0.1 kWh resolution).",
+        "kWh",
+    ),
+    "charge_energy_today": (
+        "Battery charge today",
+        "Energy charged into the battery today (0.1 kWh resolution).",
+        "kWh",
+    ),
+    "charge_energy_total": (
+        "Battery charge total",
+        "Total energy charged into the battery (0.1 kWh resolution).",
+        "kWh",
+    ),
+    "bdc_new_flag": (
+        "BDC presence flag",
+        "Indicates whether a battery DC converter (BDC) has been detected.",
+        None,
+    ),
+    "battery_voltage": (
+        "Battery voltage",
+        "Pack voltage reported via the inverter-side measurements (0.01 V resolution).",
+        "V",
+    ),
+    "battery_current": (
+        "Battery current",
+        "Current flowing between battery and inverter (positive = discharge) with 0.1 A resolution.",
+        "A",
+    ),
+    "soc": (
+        "Battery SOC",
+        "Battery state of charge reported by the inverter.",
+        "%",
+    ),
+    "vbus1_voltage": (
+        "VBUS1 voltage",
+        "BDC high-side bus voltage (0.1 V resolution).",
+        "V",
+    ),
+    "vbus2_voltage": (
+        "VBUS2 voltage",
+        "BDC low-side bus voltage (0.1 V resolution).",
+        "V",
+    ),
+    "buck_boost_current": (
+        "Buck/boost current",
+        "Current through the BDC buck/boost stage (0.1 A resolution).",
+        "A",
+    ),
+    "llc_current": (
+        "LLC stage current",
+        "Current through the LLC resonant stage (0.1 A resolution).",
+        "A",
+    ),
+    "battery_temperature_a": (
+        "Battery temperature A",
+        "Battery temperature sensor A (0.1 °C resolution).",
+        "°C",
+    ),
+    "battery_temperature_b": (
+        "Battery temperature B",
+        "Battery temperature sensor B (0.1 °C resolution).",
+        "°C",
+    ),
+    "discharge_power": (
+        "Battery discharge power",
+        "Real-time discharge power flowing from the battery (0.1 W resolution).",
+        "W",
+    ),
+    "charge_power": (
+        "Battery charge power",
+        "Real-time charge power flowing into the battery (0.1 W resolution).",
+        "W",
+    ),
+    "bms_max_volt_cell_no": (
+        "BMS max cell index",
+        "Cell index reporting the highest voltage in the battery stack (1-based).",
+        None,
+    ),
+    "bms_min_volt_cell_no": (
+        "BMS min cell index",
+        "Cell index reporting the lowest voltage in the battery stack (1-based).",
+        None,
+    ),
+    "bms_avg_temp_a": (
+        "BMS average temperature A",
+        "Average temperature reported by sensor group A (0.1 °C resolution).",
+        "°C",
+    ),
+    "bms_max_cell_temp_a": (
+        "BMS max cell temperature A",
+        "Maximum cell temperature within sensor group A (0.1 °C resolution).",
+        "°C",
+    ),
+    "bms_avg_temp_b": (
+        "BMS average temperature B",
+        "Average temperature reported by sensor group B (0.1 °C resolution).",
+        "°C",
+    ),
+    "bms_max_cell_temp_b": (
+        "BMS max cell temperature B",
+        "Maximum cell temperature within sensor group B (0.1 °C resolution).",
+        "°C",
+    ),
+    "bms_avg_temp_c": (
+        "BMS average temperature C",
+        "Average temperature reported by sensor group C (0.1 °C resolution).",
+        "°C",
+    ),
+    "bms_max_soc": (
+        "BMS max SOC",
+        "Highest state of charge observed across battery modules.",
+        "%",
+    ),
+    "bms_min_soc": (
+        "BMS min SOC",
+        "Lowest state of charge observed across battery modules.",
+        "%",
+    ),
+    "parallel_battery_num": (
+        "Parallel battery count",
+        "Number of battery modules detected in parallel.",
+        None,
+    ),
+    "bms_derate_reason": (
+        "BMS derate reason",
+        "Reason code reported by the BMS for power derating.",
+        None,
+    ),
+    "bms_gauge_fcc_ah": (
+        "BMS full charge capacity",
+        "Full charge capacity (FCC) reported by the battery fuel gauge (Ah).",
+        "Ah",
+    ),
+    "bms_gauge_rm_ah": (
+        "BMS remaining capacity",
+        "Remaining capacity (RM) reported by the battery fuel gauge (Ah).",
+        "Ah",
+    ),
+    "bms_protect1": (
+        "BMS protect flags 1",
+        "Protection bitmask word 1 from the battery management system.",
+        None,
+    ),
+    "bms_warn1": (
+        "BMS warning flags 1",
+        "Warning bitmask word 1 from the battery management system.",
+        None,
+    ),
+    "bms_fault1": (
+        "BMS fault flags 1",
+        "Fault bitmask word 1 from the battery management system.",
+        None,
+    ),
+    "bms_fault2": (
+        "BMS fault flags 2",
+        "Fault bitmask word 2 from the battery management system.",
+        None,
+    ),
+    "bat_iso_status": (
+        "Battery insulation status",
+        "Isolation detection status reported by the BMS (0 = not detected, 1 = detected).",
+        None,
+    ),
+    "batt_request_flags": (
+        "Battery request flags",
+        "Bitmask of requests from the BMS to the inverter (charge/discharge permissions).",
+        None,
+    ),
+    "bms_status": (
+        "BMS status",
+        "Overall battery management system status code.",
+        None,
+    ),
+    "bms_protect2": (
+        "BMS protect flags 2",
+        "Protection bitmask word 2 from the battery management system.",
+        None,
+    ),
+    "bms_warn2": (
+        "BMS warning flags 2",
+        "Warning bitmask word 2 from the battery management system.",
+        None,
+    ),
+    "bms_soc": (
+        "BMS SOC",
+        "State of charge reported directly by the BMS.",
+        "%",
+    ),
+    "bms_battery_voltage": (
+        "BMS battery voltage",
+        "Pack voltage reported by the BMS (0.01 V resolution).",
+        "V",
+    ),
+    "bms_battery_current": (
+        "BMS battery current",
+        "Current reported by the BMS with 0.01 A resolution (positive = discharge).",
+        "A",
+    ),
+    "bms_cell_max_temp": (
+        "BMS max cell temperature",
+        "Maximum cell temperature observed across the battery pack (0.1 °C resolution).",
+        "°C",
+    ),
+    "bms_max_charge_current": (
+        "BMS max charge current",
+        "Maximum charge current allowed by the BMS (0.01 A resolution).",
+        "A",
+    ),
+    "bms_max_discharge_current": (
+        "BMS max discharge current",
+        "Maximum discharge current allowed by the BMS (0.01 A resolution).",
+        "A",
+    ),
+    "bms_cycle_count": (
+        "BMS cycle count",
+        "Total charge/discharge cycles counted by the BMS.",
+        None,
+    ),
+    "bms_soh": (
+        "BMS state of health",
+        "Battery state of health reported by the BMS.",
+        "%",
+    ),
+    "bms_charge_volt_limit": (
+        "BMS charge voltage limit",
+        "Maximum pack voltage permitted during charge (0.01 V resolution).",
+        "V",
+    ),
+    "bms_discharge_volt_limit": (
+        "BMS discharge voltage limit",
+        "Minimum pack voltage permitted during discharge (0.01 V resolution).",
+        "V",
+    ),
+    "bms_warn3": (
+        "BMS warning flags 3",
+        "Warning bitmask word 3 from the battery management system.",
+        None,
+    ),
+    "bms_protect3": (
+        "BMS protect flags 3",
+        "Protection bitmask word 3 from the battery management system.",
+        None,
+    ),
+    "bms_cell_volt_max": (
+        "BMS max cell voltage",
+        "Highest individual cell voltage (0.001 V resolution).",
+        "V",
+    ),
+    "bms_cell_volt_min": (
+        "BMS min cell voltage",
+        "Lowest individual cell voltage (0.001 V resolution).",
+        "V",
+    ),
+}
+
+
+def resolve_attribute(attr: str, register: int) -> tuple[str, str, str | None]:
+    if attr in ATTRIBUTE_OVERRIDES:
+        return ATTRIBUTE_OVERRIDES[attr]
+
+    if match := re.match(r"input_(\d+)_(voltage|amperage|power|energy_today|energy_total)", attr):
+        idx = int(match.group(1))
+        field = match.group(2)
+        return tracker_description(idx, field)
+
+    if match := re.match(r"output_(\d+)_(voltage|amperage|power)", attr):
+        idx = int(match.group(1))
+        field = match.group(2)
+        return phase_description(idx, field)
+
+    if attr in {
+        "power_to_user",
+        "power_to_grid",
+        "power_user_load",
+        "energy_to_user_today",
+        "energy_to_user_total",
+        "energy_to_grid_today",
+        "energy_to_grid_total",
+    }:
+        return energy_flow_description(attr)
+
+    raise KeyError(f"Missing metadata for attribute {attr} (register {register})")
+
+
+SIGNED_ATTRIBUTES = {
+    "battery_current",
+    "bms_battery_current",
+    "discharge_power",
+    "charge_power",
+    "output_reactive_power",
+}
+
+ENERGY_ATTRIBUTES = {
+    "input_energy_total",
+    "output_energy_today",
+    "output_energy_total",
+    "input_1_energy_today",
+    "input_1_energy_total",
+    "input_2_energy_today",
+    "input_2_energy_total",
+    "input_3_energy_today",
+    "input_3_energy_total",
+    "input_4_energy_today",
+    "input_4_energy_total",
+    "input_5_energy_today",
+    "input_5_energy_total",
+    "input_6_energy_today",
+    "input_6_energy_total",
+    "input_7_energy_today",
+    "input_7_energy_total",
+    "input_8_energy_today",
+    "input_8_energy_total",
+    "output_reactive_energy_total",
+    "energy_to_user_today",
+    "energy_to_user_total",
+    "energy_to_grid_today",
+    "energy_to_grid_total",
+    "discharge_energy_today",
+    "discharge_energy_total",
+    "charge_energy_today",
+    "charge_energy_total",
+}
+
+
+def is_voltage_attr(attr: str) -> bool:
+    if attr.endswith("_volt_cell_no"):
+        return False
+    return (
+        "voltage" in attr
+        or attr.endswith("_volt")
+        or "_volt_" in attr
+        or attr.endswith("volt_limit")
+        or attr.endswith("volt_max")
+        or attr.endswith("volt_min")
+    )
+
+
+def determine_data_type(attr: str, length: int, scale: int, value_type: str) -> str:
+    if attr == "status_code":
+        return "inverter_status_code"
+    if attr in {"fault_code", "warning_code"}:
+        return "u16_status_word"
+    if attr == "derating_mode":
+        return "u16_raw_code"
+    if attr == "bdc_new_flag":
+        return "u16_flag"
+    if attr == "operation_hours":
+        return "u32_runtime_hours"
+    if attr == "output_reactive_power":
+        return "s32_reactive_power_decivar"
+    if attr == "output_reactive_energy_total":
+        return "u32_energy_kvarh_decitenth"
+    if attr.endswith("_ah"):
+        return "u16_ampere_hour"
+    if length == 2 and attr in ENERGY_ATTRIBUTES:
+        return "u32_energy_kwh_decitenth"
+    if length == 2:
+        if attr in SIGNED_ATTRIBUTES:
+            return "s32_power_w_decawatt"
+        return "u32_power_w_decawatt"
+    if scale == 1000:
+        if is_voltage_attr(attr):
+            return "u16_voltage_millivolt"
+        return "u16_raw"
+    if scale == 100:
+        if "current" in attr:
+            if attr in SIGNED_ATTRIBUTES:
+                return "s16_current_centiamp"
+            return "u16_current_centiamp"
+        if is_voltage_attr(attr):
+            return "u16_voltage_centivolt"
+        if attr == "grid_frequency":
+            return "u16_frequency_centihz"
+        return "u16_scaled_100"
+    if scale == 7200:
+        return "u32_runtime_hours"
+    percent_attributes = {
+        "soc",
+        "bms_soc",
+        "bms_max_soc",
+        "bms_min_soc",
+        "real_output_power_percent",
+        "bms_soh",
+    }
+    if scale == 10:
+        if attr in percent_attributes:
+            return "u16_percent"
+        if is_voltage_attr(attr):
+            return "u16_voltage_decivolt"
+        if "current" in attr or "amperage" in attr:
+            if attr in SIGNED_ATTRIBUTES:
+                return "s16_current_deciamp"
+            return "u16_current_deciamp"
+        if "temperature" in attr or "temp" in attr:
+            return "s16_temperature_decic"
+        if attr.endswith("power") or "power_" in attr:
+            return "u16_power_decawatt"
+    if scale == 1:
+        if attr in percent_attributes:
+            return "u16_percent"
+        if attr.endswith("_ah"):
+            return "u16_ampere_hour"
+    if value_type == "int":
+        return "u16_raw"
+    return "u16_raw"
+
+
+SECTION_RULES: list[tuple[str, Callable[[int], bool]]] = [
+    ("Common input telemetry (0–124)", lambda reg: 0 <= reg <= 124),
+    ("Extended common input telemetry (125–299)", lambda reg: 125 <= reg < 3000),
+    ("TL-X/TL-XH PV/AC telemetry (3000–3124)", lambda reg: 3000 <= reg <= 3124),
+    ("TL-X/TL-XH battery telemetry (3125–3199)", lambda reg: 3125 <= reg <= 3199),
+    ("TL-X/TL-XH BMS diagnostics (3200–3231)", lambda reg: 3200 <= reg <= 3231),
+]
+
+
+def assign_section(register: int) -> str:
+    for title, predicate in SECTION_RULES:
+        if predicate(register):
+            return title
+    raise ValueError(f"No section for register {register}")
+
+
+def build_register_meta() -> list[RegisterMeta]:
+    mapping = load_json(MAPPING_PATH)
+    register_families: dict[int, set[str]] = {}
+    for family, groups in mapping.items():
+        for group_name, group_entries in groups.items():
+            if not group_name.startswith("input"):
+                continue
+            for item in group_entries:
+                register_families.setdefault(item["register"], set()).add(family)
+
+    entries: list[RegisterMeta] = []
+    # combine common and TL-XH groups (deduplicate by register + attribute)
+    seen: set[tuple[int, str]] = set()
+    combined = mapping["tlx"]["input_common"] + mapping["tlx"]["input_tl_xh"]
+    for item in combined:
+        attr = item["name"]
+        register = item["register"]
+        key = (register, attr)
+        if key in seen:
+            continue
+        seen.add(key)
+        length = item.get("length", 1)
+        register_end = register + length - 1
+        value_type = item.get("value_type", "int")
+        scale = item.get("scale")
+        if scale is None:
+            scale = 1 if value_type == "int" else 10
+        name, description, unit = resolve_attribute(attr, register)
+        data_type = determine_data_type(attr, length, scale, value_type)
+        note = None
+        if attr == "operation_hours":
+            note = "Raw counter counts seconds; divide by 7200 to obtain hours."
+        if attr == "bms_battery_current":
+            note = "Positive values indicate discharge from the battery; negative values indicate charging."
+        families = tuple(sorted(register_families.get(register, {"tlx"})))
+        entries.append(
+            RegisterMeta(
+                register=register,
+                register_end=register_end,
+                attributes=(attr,),
+                name=name,
+                description=description,
+                unit=unit,
+                data_type=data_type,
+                families=families,
+                note=note,
+            )
+        )
+    entries.sort(key=lambda meta: meta.register)
+    return entries
+
+
+TYPE_DEFINITIONS: dict[str, dict] = {
+    "inverter_status_code": {
+        "kind": "enum",
+        "registers": 1,
+        "bits": 16,
+        "values": {
+            "0": {"label": "waiting"},
+            "1": {"label": "normal"},
+            "3": {"label": "fault"},
+            "5": {"label": "pv_charge"},
+            "6": {"label": "ac_charge"},
+            "7": {"label": "combined_charge"},
+            "8": {"label": "combined_charge_bypass"},
+            "9": {"label": "pv_charge_bypass"},
+            "10": {"label": "ac_charge_bypass"},
+            "11": {"label": "bypass"},
+            "12": {"label": "pv_charge_discharge"},
+        },
+        "notes": "Enum derived from Growatt protocol inverter status codes.",
+    },
+    "u16_voltage_decivolt": {
+        "kind": "scaled",
+        "registers": 1,
+        "bits": 16,
+        "scale": 10,
+        "unit": "V",
+    },
+    "u16_voltage_centivolt": {
+        "kind": "scaled",
+        "registers": 1,
+        "bits": 16,
+        "scale": 100,
+        "unit": "V",
+    },
+    "u16_voltage_millivolt": {
+        "kind": "scaled",
+        "registers": 1,
+        "bits": 16,
+        "scale": 1000,
+        "unit": "V",
+    },
+    "u16_current_deciamp": {
+        "kind": "scaled",
+        "registers": 1,
+        "bits": 16,
+        "scale": 10,
+        "unit": "A",
+    },
+    "s16_current_deciamp": {
+        "kind": "scaled_signed",
+        "registers": 1,
+        "bits": 16,
+        "scale": 10,
+        "unit": "A",
+    },
+    "u16_current_centiamp": {
+        "kind": "scaled",
+        "registers": 1,
+        "bits": 16,
+        "scale": 100,
+        "unit": "A",
+    },
+    "s16_current_centiamp": {
+        "kind": "scaled_signed",
+        "registers": 1,
+        "bits": 16,
+        "scale": 100,
+        "unit": "A",
+    },
+    "s16_temperature_decic": {
+        "kind": "scaled_signed",
+        "registers": 1,
+        "bits": 16,
+        "scale": 10,
+        "unit": "°C",
+    },
+    "u16_percent": {
+        "kind": "scaled",
+        "registers": 1,
+        "bits": 16,
+        "scale": 1,
+        "unit": "%",
+    },
+    "u16_ampere_hour": {
+        "kind": "scaled",
+        "registers": 1,
+        "bits": 16,
+        "scale": 1,
+        "unit": "Ah",
+    },
+    "u16_flag": {
+        "kind": "enum",
+        "registers": 1,
+        "bits": 16,
+        "values": {"0": {"label": "no"}, "1": {"label": "yes"}},
+    },
+    "u16_raw": {
+        "kind": "raw",
+        "registers": 1,
+        "bits": 16,
+    },
+    "u16_raw_code": {
+        "kind": "raw",
+        "registers": 1,
+        "bits": 16,
+        "notes": "Vendor-specific state code.",
+    },
+    "u16_status_word": {
+        "kind": "raw",
+        "registers": 1,
+        "bits": 16,
+        "notes": "Vendor-specific fault/warning bitmask.",
+    },
+    "u32_power_w_decawatt": {
+        "kind": "scaled",
+        "registers": 2,
+        "bits": 32,
+        "scale": 10,
+        "unit": "W",
+        "notes": "Unsigned 32-bit value stored as high/low words with 0.1 W resolution.",
+    },
+    "s32_power_w_decawatt": {
+        "kind": "scaled_signed",
+        "registers": 2,
+        "bits": 32,
+        "scale": 10,
+        "unit": "W",
+        "notes": "Signed 32-bit value stored as high/low words with 0.1 W resolution.",
+    },
+    "s32_reactive_power_decivar": {
+        "kind": "scaled_signed",
+        "registers": 2,
+        "bits": 32,
+        "scale": 10,
+        "unit": "var",
+        "notes": "Signed 32-bit reactive power measurement with 0.1 var resolution.",
+    },
+    "u16_power_decawatt": {
+        "kind": "scaled",
+        "registers": 1,
+        "bits": 16,
+        "scale": 10,
+        "unit": "W",
+    },
+    "u32_energy_kwh_decitenth": {
+        "kind": "scaled",
+        "registers": 2,
+        "bits": 32,
+        "scale": 10,
+        "unit": "kWh",
+        "notes": "Cumulative energy counter with 0.1 kWh resolution (high word first).",
+    },
+    "u32_energy_kvarh_decitenth": {
+        "kind": "scaled",
+        "registers": 2,
+        "bits": 32,
+        "scale": 10,
+        "unit": "kvarh",
+        "notes": "Cumulative reactive energy counter with 0.1 kvarh resolution (high word first).",
+    },
+    "u32_runtime_hours": {
+        "kind": "scaled",
+        "registers": 2,
+        "bits": 32,
+        "scale": 7200,
+        "unit": "h",
+        "notes": "Divide raw seconds by 7200 to obtain hours.",
+    },
+    "u16_scaled_100": {
+        "kind": "scaled",
+        "registers": 1,
+        "bits": 16,
+        "scale": 100,
+    },
+    "u16_frequency_centihz": {
+        "kind": "scaled",
+        "registers": 1,
+        "bits": 16,
+        "scale": 100,
+        "unit": "Hz",
+        "notes": "Divide by 100 to obtain the grid frequency in hertz.",
+    },
+}
+
+
+SECTION_TITLE_ORDER = [title for title, _ in SECTION_RULES]
+
+
+def rebuild_spec_input(entries: Iterable[RegisterMeta]) -> list[dict]:
+    result: list[dict] = []
+    current_section: str | None = None
+    for meta in entries:
+        section = assign_section(meta.register)
+        if section != current_section:
+            result.append({"type": "section", "title": section})
+            current_section = section
+        entry: dict = {
+            "type": "entry",
+            "section": section,
+            "register": meta.register,
+            "register_start": meta.register,
+            "register_end": meta.register_end,
+            "name": meta.name,
+            "description": meta.description,
+            "access": meta.access,
+            "unit": meta.unit,
+            "data_type": meta.data_type,
+        }
+        if meta.note:
+            entry["note"] = meta.note
+        if meta.attributes:
+            entry["attributes"] = list(meta.attributes)
+        result.append(entry)
+    return result
+
+
+def update_spec_file(entries: list[RegisterMeta]):
+    spec = load_json(SPEC_PATH)
+    spec["input"] = rebuild_spec_input(entries)
+    with SPEC_PATH.open("w", encoding="utf-8") as handle:
+        json.dump(spec, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+
+def update_data_types(entries: list[RegisterMeta]):
+    data = load_json(DATA_TYPES_PATH)
+    types = data.setdefault("types", {})
+    for type_name, definition in TYPE_DEFINITIONS.items():
+        existing = types.get(type_name)
+        if existing:
+            continue
+        types[type_name] = definition
+
+    register_types: list[dict] = data.setdefault("register_types", [])
+    handled_registers = {meta.register for meta in entries}
+    # Remove existing entries for the registers we cover in the input table.
+    preserved_families: dict[int, set[str]] = {}
+    filtered: list[dict] = []
+    for item in register_types:
+        if (
+            item.get("table") == "input"
+            and item.get("register") in handled_registers
+            and "tlx" in item.get("families", [])
+        ):
+            preserved_families[item["register"]] = set(item.get("families", []))
+            continue
+        filtered.append(item)
+    register_types = filtered
+    for meta in entries:
+        families = set(preserved_families.get(meta.register, set())) | set(meta.families)
+        item = {
+            "table": "input",
+            "register": meta.register,
+            "register_end": meta.register_end,
+            "type": meta.data_type,
+            "attributes": list(meta.attributes),
+            "families": sorted(families),
+        }
+        register_types.append(item)
+    # Keep register types sorted for determinism.
+    register_types.sort(key=lambda item: (item["table"], item["register"]))
+    data["register_types"] = register_types
+    with DATA_TYPES_PATH.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+
+def main():
+    entries = build_register_meta()
+    update_spec_file(entries)
+    update_data_types(entries)
+    print(f"Updated input register spec for {len(entries)} entries.")
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/growatt_register_data_types.json
+++ b/doc/growatt_register_data_types.json
@@ -979,6 +979,216 @@
         }
       ],
       "notes": "Date enable register followed by up to nine override slots for the selected day."
+    },
+    "inverter_status_code": {
+      "kind": "enum",
+      "registers": 1,
+      "bits": 16,
+      "values": {
+        "0": {
+          "label": "waiting"
+        },
+        "1": {
+          "label": "normal"
+        },
+        "3": {
+          "label": "fault"
+        },
+        "5": {
+          "label": "pv_charge"
+        },
+        "6": {
+          "label": "ac_charge"
+        },
+        "7": {
+          "label": "combined_charge"
+        },
+        "8": {
+          "label": "combined_charge_bypass"
+        },
+        "9": {
+          "label": "pv_charge_bypass"
+        },
+        "10": {
+          "label": "ac_charge_bypass"
+        },
+        "11": {
+          "label": "bypass"
+        },
+        "12": {
+          "label": "pv_charge_discharge"
+        }
+      },
+      "notes": "Enum derived from Growatt protocol inverter status codes."
+    },
+    "u16_voltage_decivolt": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 10,
+      "unit": "V"
+    },
+    "u16_voltage_centivolt": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 100,
+      "unit": "V"
+    },
+    "u16_voltage_millivolt": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 1000,
+      "unit": "V"
+    },
+    "u16_current_deciamp": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 10,
+      "unit": "A"
+    },
+    "s16_current_deciamp": {
+      "kind": "scaled_signed",
+      "registers": 1,
+      "bits": 16,
+      "scale": 10,
+      "unit": "A"
+    },
+    "u16_current_centiamp": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 100,
+      "unit": "A"
+    },
+    "s16_temperature_decic": {
+      "kind": "scaled_signed",
+      "registers": 1,
+      "bits": 16,
+      "scale": 10,
+      "unit": "°C"
+    },
+    "u16_percent": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 1,
+      "unit": "%"
+    },
+    "u16_ampere_hour": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 1,
+      "unit": "Ah"
+    },
+    "u16_flag": {
+      "kind": "enum",
+      "registers": 1,
+      "bits": 16,
+      "values": {
+        "0": {
+          "label": "no"
+        },
+        "1": {
+          "label": "yes"
+        }
+      }
+    },
+    "u16_raw": {
+      "kind": "raw",
+      "registers": 1,
+      "bits": 16
+    },
+    "u16_raw_code": {
+      "kind": "raw",
+      "registers": 1,
+      "bits": 16,
+      "notes": "Vendor-specific state code."
+    },
+    "u16_status_word": {
+      "kind": "raw",
+      "registers": 1,
+      "bits": 16,
+      "notes": "Vendor-specific fault/warning bitmask."
+    },
+    "u32_power_w_decawatt": {
+      "kind": "scaled",
+      "registers": 2,
+      "bits": 32,
+      "scale": 10,
+      "unit": "W",
+      "notes": "Unsigned 32-bit value stored as high/low words with 0.1 W resolution."
+    },
+    "s32_power_w_decawatt": {
+      "kind": "scaled_signed",
+      "registers": 2,
+      "bits": 32,
+      "scale": 10,
+      "unit": "W",
+      "notes": "Signed 32-bit value stored as high/low words with 0.1 W resolution."
+    },
+    "u16_power_decawatt": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 10,
+      "unit": "W"
+    },
+    "u32_energy_kwh_decitenth": {
+      "kind": "scaled",
+      "registers": 2,
+      "bits": 32,
+      "scale": 10,
+      "unit": "kWh",
+      "notes": "Cumulative energy counter with 0.1 kWh resolution (high word first)."
+    },
+    "u32_runtime_hours": {
+      "kind": "scaled",
+      "registers": 2,
+      "bits": 32,
+      "scale": 7200,
+      "unit": "h",
+      "notes": "Divide raw seconds by 7200 to obtain hours."
+    },
+    "u16_scaled_100": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 100
+    },
+    "s32_reactive_power_decivar": {
+      "kind": "scaled_signed",
+      "registers": 2,
+      "bits": 32,
+      "scale": 10,
+      "unit": "var",
+      "notes": "Signed 32-bit reactive power measurement with 0.1 var resolution."
+    },
+    "u32_energy_kvarh_decitenth": {
+      "kind": "scaled",
+      "registers": 2,
+      "bits": 32,
+      "scale": 10,
+      "unit": "kvarh",
+      "notes": "Cumulative reactive energy counter with 0.1 kvarh resolution (high word first)."
+    },
+    "u16_frequency_centihz": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 100,
+      "unit": "Hz",
+      "notes": "Divide by 100 to obtain the grid frequency in hertz."
+    },
+    "s16_current_centiamp": {
+      "kind": "scaled_signed",
+      "registers": 1,
+      "bits": 16,
+      "scale": 100,
+      "unit": "A"
     }
   },
   "register_types": [
@@ -1792,7 +2002,7 @@
       "table": "input",
       "register": 0,
       "register_end": 0,
-      "type": "u16_scale10",
+      "type": "inverter_status_code",
       "attributes": [
         "status_code"
       ],
@@ -1806,18 +2016,14 @@
       "table": "input",
       "register": 1,
       "register_end": 2,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
-        "input_1_voltage",
         "input_power"
       ],
       "families": [
         "offgrid",
         "tl3",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u16_scale10"
       ]
     },
     {
@@ -1835,26 +2041,22 @@
     {
       "table": "input",
       "register": 3,
-      "register_end": 4,
-      "type": "u16_scale10",
+      "register_end": 3,
+      "type": "u16_voltage_decivolt",
       "attributes": [
-        "input_1_power",
         "input_1_voltage"
       ],
       "families": [
         "offgrid",
         "tl3",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u32_scale10"
       ]
     },
     {
       "table": "input",
       "register": 4,
       "register_end": 4,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "input_1_amperage"
       ],
@@ -1867,10 +2069,9 @@
       "table": "input",
       "register": 5,
       "register_end": 6,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
-        "input_1_power",
-        "input_2_power"
+        "input_1_power"
       ],
       "families": [
         "offgrid",
@@ -1882,9 +2083,8 @@
       "table": "input",
       "register": 7,
       "register_end": 7,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
-        "input_1_amperage",
         "input_2_voltage"
       ],
       "families": [
@@ -1897,7 +2097,7 @@
       "table": "input",
       "register": 8,
       "register_end": 8,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "input_2_amperage"
       ],
@@ -1911,10 +2111,9 @@
       "table": "input",
       "register": 9,
       "register_end": 10,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
-        "input_2_power",
-        "output_active_power"
+        "input_2_power"
       ],
       "families": [
         "offgrid",
@@ -1925,25 +2124,21 @@
     {
       "table": "input",
       "register": 11,
-      "register_end": 12,
-      "type": "u16_scale10",
+      "register_end": 11,
+      "type": "u16_voltage_decivolt",
       "attributes": [
-        "input_3_voltage",
-        "output_power"
+        "input_3_voltage"
       ],
       "families": [
         "tl3",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u32_scale10"
       ]
     },
     {
       "table": "input",
       "register": 12,
       "register_end": 12,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "input_3_amperage"
       ],
@@ -1955,19 +2150,14 @@
       "table": "input",
       "register": 13,
       "register_end": 14,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
-        "charge_power",
-        "grid_frequency",
         "input_3_power"
       ],
       "families": [
         "offgrid",
         "tl3",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u16_scale100"
       ]
     },
     {
@@ -1986,10 +2176,9 @@
       "table": "input",
       "register": 15,
       "register_end": 15,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
+        "input_4_voltage"
       ],
       "families": [
         "tl3",
@@ -1999,35 +2188,27 @@
     {
       "table": "input",
       "register": 16,
-      "register_end": 17,
-      "type": "u16_scale10",
+      "register_end": 16,
+      "type": "u16_current_deciamp",
       "attributes": [
-        "input_4_amperage",
-        "output_1_power"
+        "input_4_amperage"
       ],
       "families": [
         "tl3",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u32_scale10"
       ]
     },
     {
       "table": "input",
       "register": 17,
       "register_end": 18,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
-        "battery_voltage",
         "input_4_power"
       ],
       "families": [
         "offgrid",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u16_scale100"
       ]
     },
     {
@@ -2048,11 +2229,9 @@
       "table": "input",
       "register": 19,
       "register_end": 19,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
+        "input_5_voltage"
       ],
       "families": [
         "offgrid",
@@ -2063,37 +2242,28 @@
     {
       "table": "input",
       "register": 20,
-      "register_end": 21,
-      "type": "u16_scale10",
+      "register_end": 20,
+      "type": "u16_current_deciamp",
       "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
+        "input_5_amperage"
       ],
       "families": [
         "offgrid",
         "tl3",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u32_scale10"
       ]
     },
     {
       "table": "input",
       "register": 21,
       "register_end": 22,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
-        "grid_frequency",
         "input_5_power"
       ],
       "families": [
         "offgrid",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u16_scale100"
       ]
     },
     {
@@ -2114,55 +2284,41 @@
       "table": "input",
       "register": 23,
       "register_end": 23,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
+        "input_6_voltage"
       ],
       "families": [
         "offgrid",
         "tl3",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u16_scale100"
       ]
     },
     {
       "table": "input",
       "register": 24,
-      "register_end": 25,
-      "type": "u16_scale10",
+      "register_end": 24,
+      "type": "u16_current_deciamp",
       "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
+        "input_6_amperage"
       ],
       "families": [
         "offgrid",
         "tl3",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u32_scale10"
       ]
     },
     {
       "table": "input",
       "register": 25,
       "register_end": 26,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
-        "input_6_power",
-        "inverter_temperature"
+        "input_6_power"
       ],
       "families": [
         "offgrid",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u16_scale10"
       ]
     },
     {
@@ -2186,10 +2342,9 @@
       "table": "input",
       "register": 27,
       "register_end": 27,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
-        "input_7_voltage",
-        "load_percent"
+        "input_7_voltage"
       ],
       "families": [
         "offgrid",
@@ -2199,37 +2354,28 @@
     {
       "table": "input",
       "register": 28,
-      "register_end": 29,
-      "type": "u16_scale10",
+      "register_end": 28,
+      "type": "u16_current_deciamp",
       "attributes": [
-        "battery_port_voltage",
-        "input_7_amperage",
-        "output_energy_total"
+        "input_7_amperage"
       ],
       "families": [
         "offgrid",
         "tl3",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u32_scale10"
       ]
     },
     {
       "table": "input",
       "register": 29,
       "register_end": 30,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
-        "battery_bus_voltage",
         "input_7_power"
       ],
       "families": [
         "offgrid",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u16_scale10"
       ]
     },
     {
@@ -2249,7 +2395,7 @@
       "table": "input",
       "register": 31,
       "register_end": 31,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "input_8_voltage"
       ],
@@ -2261,10 +2407,9 @@
       "table": "input",
       "register": 32,
       "register_end": 32,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
+        "input_8_amperage"
       ],
       "families": [
         "tl3",
@@ -2275,7 +2420,7 @@
       "table": "input",
       "register": 33,
       "register_end": 34,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "input_8_power"
       ],
@@ -2299,7 +2444,7 @@
       "table": "input",
       "register": 35,
       "register_end": 36,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "output_power"
       ],
@@ -2311,7 +2456,7 @@
       "table": "input",
       "register": 37,
       "register_end": 37,
-      "type": "u16_scale100",
+      "type": "u16_frequency_centihz",
       "attributes": [
         "grid_frequency"
       ],
@@ -2323,7 +2468,7 @@
       "table": "input",
       "register": 38,
       "register_end": 38,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "output_1_voltage"
       ],
@@ -2335,7 +2480,7 @@
       "table": "input",
       "register": 39,
       "register_end": 39,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "output_1_amperage"
       ],
@@ -2347,17 +2492,13 @@
       "table": "input",
       "register": 40,
       "register_end": 41,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
-        "fault_code",
         "output_1_power"
       ],
       "families": [
         "tl3",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u16_scale10"
       ]
     },
     {
@@ -2376,11 +2517,9 @@
       "table": "input",
       "register": 42,
       "register_end": 42,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
-        "fault_code",
-        "output_2_voltage",
-        "p_bus_voltage"
+        "output_2_voltage"
       ],
       "families": [
         "offgrid",
@@ -2392,11 +2531,9 @@
       "table": "input",
       "register": 43,
       "register_end": 43,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
-        "n_bus_voltage",
-        "output_2_amperage",
-        "warning_code"
+        "output_2_amperage"
       ],
       "families": [
         "offgrid",
@@ -2408,7 +2545,7 @@
       "table": "input",
       "register": 44,
       "register_end": 45,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "output_2_power"
       ],
@@ -2420,7 +2557,7 @@
       "table": "input",
       "register": 46,
       "register_end": 46,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "output_3_voltage"
       ],
@@ -2432,10 +2569,8 @@
       "table": "input",
       "register": 47,
       "register_end": 47,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
-        "constant_power",
-        "derating_mode",
         "output_3_amperage"
       ],
       "families": [
@@ -2448,9 +2583,8 @@
       "table": "input",
       "register": 48,
       "register_end": 49,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
-        "input_1_energy_today",
         "output_3_power"
       ],
       "families": [
@@ -2489,7 +2623,7 @@
       "table": "input",
       "register": 53,
       "register_end": 54,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "output_energy_today"
       ],
@@ -2514,7 +2648,7 @@
       "table": "input",
       "register": 55,
       "register_end": 56,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "output_energy_total"
       ],
@@ -2540,7 +2674,7 @@
       "table": "input",
       "register": 57,
       "register_end": 58,
-      "type": "u32_scale7200",
+      "type": "u32_runtime_hours",
       "attributes": [
         "operation_hours"
       ],
@@ -2566,7 +2700,7 @@
       "table": "input",
       "register": 59,
       "register_end": 60,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_1_energy_today"
       ],
@@ -2592,7 +2726,7 @@
       "table": "input",
       "register": 61,
       "register_end": 62,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_1_energy_total"
       ],
@@ -2618,7 +2752,7 @@
       "table": "input",
       "register": 63,
       "register_end": 64,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_2_energy_today"
       ],
@@ -2647,17 +2781,13 @@
       "table": "input",
       "register": 65,
       "register_end": 66,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
-        "input_2_energy_total",
-        "warning_value"
+        "input_2_energy_total"
       ],
       "families": [
         "tl3",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u16_scale10"
       ]
     },
     {
@@ -2681,7 +2811,7 @@
       "table": "input",
       "register": 67,
       "register_end": 68,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_3_energy_today"
       ],
@@ -2705,9 +2835,8 @@
       "table": "input",
       "register": 69,
       "register_end": 70,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
-        "discharge_power",
         "input_3_energy_total"
       ],
       "families": [
@@ -2719,7 +2848,7 @@
       "table": "input",
       "register": 71,
       "register_end": 72,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_4_energy_today"
       ],
@@ -2731,24 +2860,20 @@
       "table": "input",
       "register": 73,
       "register_end": 74,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
-        "battery_discharge_amperage",
         "input_4_energy_total"
       ],
       "families": [
         "offgrid",
         "tlx"
-      ],
-      "type_conflicts": [
-        "u16_scale10"
       ]
     },
     {
       "table": "input",
       "register": 75,
       "register_end": 76,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_5_energy_today"
       ],
@@ -2760,9 +2885,8 @@
       "table": "input",
       "register": 77,
       "register_end": 78,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
-        "battery_power",
         "input_5_energy_total"
       ],
       "families": [
@@ -2774,7 +2898,7 @@
       "table": "input",
       "register": 79,
       "register_end": 80,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_6_energy_today"
       ],
@@ -2786,7 +2910,7 @@
       "table": "input",
       "register": 81,
       "register_end": 82,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_6_energy_total"
       ],
@@ -2798,7 +2922,7 @@
       "table": "input",
       "register": 83,
       "register_end": 84,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_7_energy_today"
       ],
@@ -2810,7 +2934,7 @@
       "table": "input",
       "register": 85,
       "register_end": 86,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_7_energy_total"
       ],
@@ -2822,7 +2946,7 @@
       "table": "input",
       "register": 87,
       "register_end": 88,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_8_energy_today"
       ],
@@ -2834,7 +2958,7 @@
       "table": "input",
       "register": 89,
       "register_end": 90,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_8_energy_total"
       ],
@@ -2846,7 +2970,7 @@
       "table": "input",
       "register": 91,
       "register_end": 92,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_energy_total"
       ],
@@ -2858,7 +2982,7 @@
       "table": "input",
       "register": 93,
       "register_end": 93,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "inverter_temperature"
       ],
@@ -2870,7 +2994,7 @@
       "table": "input",
       "register": 94,
       "register_end": 94,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "ipm_temperature"
       ],
@@ -2882,7 +3006,7 @@
       "table": "input",
       "register": 95,
       "register_end": 95,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "boost_temperature"
       ],
@@ -2894,7 +3018,7 @@
       "table": "input",
       "register": 98,
       "register_end": 98,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "p_bus_voltage"
       ],
@@ -2906,7 +3030,7 @@
       "table": "input",
       "register": 99,
       "register_end": 99,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "n_bus_voltage"
       ],
@@ -2918,7 +3042,7 @@
       "table": "input",
       "register": 101,
       "register_end": 101,
-      "type": "u16_scale10",
+      "type": "u16_percent",
       "attributes": [
         "real_output_power_percent"
       ],
@@ -2930,7 +3054,7 @@
       "table": "input",
       "register": 104,
       "register_end": 104,
-      "type": "u16_scale10",
+      "type": "u16_raw_code",
       "attributes": [
         "derating_mode"
       ],
@@ -2942,7 +3066,7 @@
       "table": "input",
       "register": 105,
       "register_end": 105,
-      "type": "u16_scale10",
+      "type": "u16_status_word",
       "attributes": [
         "fault_code"
       ],
@@ -2954,7 +3078,7 @@
       "table": "input",
       "register": 110,
       "register_end": 111,
-      "type": "u32_scale10",
+      "type": "u16_status_word",
       "attributes": [
         "warning_code"
       ],
@@ -2966,7 +3090,7 @@
       "table": "input",
       "register": 234,
       "register_end": 235,
-      "type": "u32_scale10",
+      "type": "s32_reactive_power_decivar",
       "attributes": [
         "output_reactive_power"
       ],
@@ -2978,7 +3102,7 @@
       "table": "input",
       "register": 236,
       "register_end": 237,
-      "type": "u32_scale10",
+      "type": "u32_energy_kvarh_decitenth",
       "attributes": [
         "output_reactive_energy_total"
       ],
@@ -3146,7 +3270,7 @@
       "table": "input",
       "register": 3000,
       "register_end": 3000,
-      "type": "u16_scale10",
+      "type": "inverter_status_code",
       "attributes": [
         "status_code"
       ],
@@ -3158,7 +3282,7 @@
       "table": "input",
       "register": 3001,
       "register_end": 3002,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "input_power"
       ],
@@ -3170,7 +3294,7 @@
       "table": "input",
       "register": 3003,
       "register_end": 3003,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "input_1_voltage"
       ],
@@ -3182,7 +3306,7 @@
       "table": "input",
       "register": 3004,
       "register_end": 3004,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "input_1_amperage"
       ],
@@ -3194,7 +3318,7 @@
       "table": "input",
       "register": 3005,
       "register_end": 3006,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "input_1_power"
       ],
@@ -3206,7 +3330,7 @@
       "table": "input",
       "register": 3007,
       "register_end": 3007,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "input_2_voltage"
       ],
@@ -3218,7 +3342,7 @@
       "table": "input",
       "register": 3008,
       "register_end": 3008,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "input_2_amperage"
       ],
@@ -3230,7 +3354,7 @@
       "table": "input",
       "register": 3009,
       "register_end": 3010,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "input_2_power"
       ],
@@ -3242,7 +3366,7 @@
       "table": "input",
       "register": 3011,
       "register_end": 3011,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "input_3_voltage"
       ],
@@ -3254,7 +3378,7 @@
       "table": "input",
       "register": 3012,
       "register_end": 3012,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "input_3_amperage"
       ],
@@ -3266,7 +3390,7 @@
       "table": "input",
       "register": 3013,
       "register_end": 3014,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "input_3_power"
       ],
@@ -3278,7 +3402,7 @@
       "table": "input",
       "register": 3015,
       "register_end": 3015,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "input_4_voltage"
       ],
@@ -3290,7 +3414,7 @@
       "table": "input",
       "register": 3016,
       "register_end": 3016,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "input_4_amperage"
       ],
@@ -3302,7 +3426,7 @@
       "table": "input",
       "register": 3017,
       "register_end": 3018,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "input_4_power"
       ],
@@ -3314,7 +3438,7 @@
       "table": "input",
       "register": 3021,
       "register_end": 3022,
-      "type": "u32_scale10",
+      "type": "s32_reactive_power_decivar",
       "attributes": [
         "output_reactive_power"
       ],
@@ -3326,7 +3450,7 @@
       "table": "input",
       "register": 3023,
       "register_end": 3024,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "output_power"
       ],
@@ -3338,7 +3462,7 @@
       "table": "input",
       "register": 3025,
       "register_end": 3025,
-      "type": "u16_scale100",
+      "type": "u16_frequency_centihz",
       "attributes": [
         "grid_frequency"
       ],
@@ -3350,7 +3474,7 @@
       "table": "input",
       "register": 3026,
       "register_end": 3026,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "output_1_voltage"
       ],
@@ -3362,7 +3486,7 @@
       "table": "input",
       "register": 3027,
       "register_end": 3027,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "output_1_amperage"
       ],
@@ -3374,7 +3498,7 @@
       "table": "input",
       "register": 3028,
       "register_end": 3029,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "output_1_power"
       ],
@@ -3386,7 +3510,7 @@
       "table": "input",
       "register": 3030,
       "register_end": 3030,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "output_2_voltage"
       ],
@@ -3398,7 +3522,7 @@
       "table": "input",
       "register": 3031,
       "register_end": 3031,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "output_2_amperage"
       ],
@@ -3410,7 +3534,7 @@
       "table": "input",
       "register": 3032,
       "register_end": 3033,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "output_2_power"
       ],
@@ -3422,7 +3546,7 @@
       "table": "input",
       "register": 3034,
       "register_end": 3034,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "output_3_voltage"
       ],
@@ -3434,7 +3558,7 @@
       "table": "input",
       "register": 3035,
       "register_end": 3035,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "output_3_amperage"
       ],
@@ -3446,7 +3570,7 @@
       "table": "input",
       "register": 3036,
       "register_end": 3037,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "output_3_power"
       ],
@@ -3458,7 +3582,7 @@
       "table": "input",
       "register": 3041,
       "register_end": 3042,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "power_to_user"
       ],
@@ -3471,7 +3595,7 @@
       "table": "input",
       "register": 3043,
       "register_end": 3044,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "power_to_grid"
       ],
@@ -3484,7 +3608,7 @@
       "table": "input",
       "register": 3045,
       "register_end": 3046,
-      "type": "u32_scale10",
+      "type": "u32_power_w_decawatt",
       "attributes": [
         "power_user_load"
       ],
@@ -3497,7 +3621,7 @@
       "table": "input",
       "register": 3047,
       "register_end": 3048,
-      "type": "u32_scale7200",
+      "type": "u32_runtime_hours",
       "attributes": [
         "operation_hours"
       ],
@@ -3509,7 +3633,7 @@
       "table": "input",
       "register": 3049,
       "register_end": 3050,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "output_energy_today"
       ],
@@ -3521,7 +3645,7 @@
       "table": "input",
       "register": 3051,
       "register_end": 3052,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "output_energy_total"
       ],
@@ -3533,7 +3657,7 @@
       "table": "input",
       "register": 3053,
       "register_end": 3054,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_energy_total"
       ],
@@ -3545,7 +3669,7 @@
       "table": "input",
       "register": 3055,
       "register_end": 3056,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_1_energy_today"
       ],
@@ -3557,7 +3681,7 @@
       "table": "input",
       "register": 3057,
       "register_end": 3058,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_1_energy_total"
       ],
@@ -3569,7 +3693,7 @@
       "table": "input",
       "register": 3059,
       "register_end": 3060,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_2_energy_today"
       ],
@@ -3581,7 +3705,7 @@
       "table": "input",
       "register": 3061,
       "register_end": 3062,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_2_energy_total"
       ],
@@ -3593,7 +3717,7 @@
       "table": "input",
       "register": 3063,
       "register_end": 3064,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_3_energy_today"
       ],
@@ -3605,7 +3729,7 @@
       "table": "input",
       "register": 3065,
       "register_end": 3066,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_3_energy_total"
       ],
@@ -3617,7 +3741,7 @@
       "table": "input",
       "register": 3067,
       "register_end": 3068,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "energy_to_user_today"
       ],
@@ -3630,7 +3754,7 @@
       "table": "input",
       "register": 3069,
       "register_end": 3070,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "energy_to_user_total"
       ],
@@ -3643,7 +3767,7 @@
       "table": "input",
       "register": 3071,
       "register_end": 3072,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "energy_to_grid_today"
       ],
@@ -3656,7 +3780,7 @@
       "table": "input",
       "register": 3073,
       "register_end": 3074,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "energy_to_grid_total"
       ],
@@ -3669,7 +3793,7 @@
       "table": "input",
       "register": 3086,
       "register_end": 3086,
-      "type": "u16_scale10",
+      "type": "u16_raw_code",
       "attributes": [
         "derating_mode"
       ],
@@ -3681,7 +3805,7 @@
       "table": "input",
       "register": 3093,
       "register_end": 3093,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "inverter_temperature"
       ],
@@ -3693,7 +3817,7 @@
       "table": "input",
       "register": 3094,
       "register_end": 3094,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "ipm_temperature"
       ],
@@ -3705,7 +3829,7 @@
       "table": "input",
       "register": 3095,
       "register_end": 3095,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "boost_temperature"
       ],
@@ -3717,7 +3841,7 @@
       "table": "input",
       "register": 3097,
       "register_end": 3097,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "comm_board_temperature"
       ],
@@ -3730,7 +3854,7 @@
       "table": "input",
       "register": 3098,
       "register_end": 3098,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "p_bus_voltage"
       ],
@@ -3742,7 +3866,7 @@
       "table": "input",
       "register": 3099,
       "register_end": 3099,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "n_bus_voltage"
       ],
@@ -3754,7 +3878,7 @@
       "table": "input",
       "register": 3101,
       "register_end": 3101,
-      "type": "u16_scale10",
+      "type": "u16_percent",
       "attributes": [
         "real_output_power_percent"
       ],
@@ -3766,7 +3890,7 @@
       "table": "input",
       "register": 3105,
       "register_end": 3105,
-      "type": "u16_scale10",
+      "type": "u16_status_word",
       "attributes": [
         "fault_code"
       ],
@@ -3778,7 +3902,7 @@
       "table": "input",
       "register": 3110,
       "register_end": 3111,
-      "type": "u32_scale10",
+      "type": "u16_status_word",
       "attributes": [
         "warning_code"
       ],
@@ -3790,7 +3914,7 @@
       "table": "input",
       "register": 3111,
       "register_end": 3111,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "present_fft_a"
       ],
@@ -3803,7 +3927,7 @@
       "table": "input",
       "register": 3115,
       "register_end": 3115,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "inv_start_delay"
       ],
@@ -3816,7 +3940,7 @@
       "table": "input",
       "register": 3125,
       "register_end": 3126,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "discharge_energy_today"
       ],
@@ -3829,7 +3953,7 @@
       "table": "input",
       "register": 3127,
       "register_end": 3128,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "discharge_energy_total"
       ],
@@ -3842,7 +3966,7 @@
       "table": "input",
       "register": 3129,
       "register_end": 3130,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "charge_energy_today"
       ],
@@ -3855,7 +3979,7 @@
       "table": "input",
       "register": 3131,
       "register_end": 3132,
-      "type": "u32_scale10",
+      "type": "u32_energy_kwh_decitenth",
       "attributes": [
         "charge_energy_total"
       ],
@@ -3868,7 +3992,7 @@
       "table": "input",
       "register": 3164,
       "register_end": 3164,
-      "type": "u16_scale10",
+      "type": "u16_flag",
       "attributes": [
         "bdc_new_flag"
       ],
@@ -3881,7 +4005,7 @@
       "table": "input",
       "register": 3169,
       "register_end": 3169,
-      "type": "u16_scale100",
+      "type": "u16_voltage_centivolt",
       "attributes": [
         "battery_voltage"
       ],
@@ -3894,7 +4018,7 @@
       "table": "input",
       "register": 3170,
       "register_end": 3170,
-      "type": "u16_scale10",
+      "type": "s16_current_deciamp",
       "attributes": [
         "battery_current"
       ],
@@ -3907,7 +4031,7 @@
       "table": "input",
       "register": 3171,
       "register_end": 3171,
-      "type": "u16_scale10",
+      "type": "u16_percent",
       "attributes": [
         "soc"
       ],
@@ -3920,7 +4044,7 @@
       "table": "input",
       "register": 3172,
       "register_end": 3172,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "vbus1_voltage"
       ],
@@ -3933,7 +4057,7 @@
       "table": "input",
       "register": 3173,
       "register_end": 3173,
-      "type": "u16_scale10",
+      "type": "u16_voltage_decivolt",
       "attributes": [
         "vbus2_voltage"
       ],
@@ -3946,7 +4070,7 @@
       "table": "input",
       "register": 3174,
       "register_end": 3174,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "buck_boost_current"
       ],
@@ -3959,7 +4083,7 @@
       "table": "input",
       "register": 3175,
       "register_end": 3175,
-      "type": "u16_scale10",
+      "type": "u16_current_deciamp",
       "attributes": [
         "llc_current"
       ],
@@ -3972,7 +4096,7 @@
       "table": "input",
       "register": 3176,
       "register_end": 3176,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "battery_temperature_a"
       ],
@@ -3985,7 +4109,7 @@
       "table": "input",
       "register": 3177,
       "register_end": 3177,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "battery_temperature_b"
       ],
@@ -3998,7 +4122,7 @@
       "table": "input",
       "register": 3178,
       "register_end": 3179,
-      "type": "u32_scale10",
+      "type": "s32_power_w_decawatt",
       "attributes": [
         "discharge_power"
       ],
@@ -4011,7 +4135,7 @@
       "table": "input",
       "register": 3180,
       "register_end": 3181,
-      "type": "u32_scale10",
+      "type": "s32_power_w_decawatt",
       "attributes": [
         "charge_power"
       ],
@@ -4024,7 +4148,7 @@
       "table": "input",
       "register": 3189,
       "register_end": 3189,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_max_volt_cell_no"
       ],
@@ -4037,7 +4161,7 @@
       "table": "input",
       "register": 3190,
       "register_end": 3190,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_min_volt_cell_no"
       ],
@@ -4050,7 +4174,7 @@
       "table": "input",
       "register": 3191,
       "register_end": 3191,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "bms_avg_temp_a"
       ],
@@ -4063,7 +4187,7 @@
       "table": "input",
       "register": 3192,
       "register_end": 3192,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "bms_max_cell_temp_a"
       ],
@@ -4076,7 +4200,7 @@
       "table": "input",
       "register": 3193,
       "register_end": 3193,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "bms_avg_temp_b"
       ],
@@ -4089,7 +4213,7 @@
       "table": "input",
       "register": 3194,
       "register_end": 3194,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "bms_max_cell_temp_b"
       ],
@@ -4102,7 +4226,7 @@
       "table": "input",
       "register": 3195,
       "register_end": 3195,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "bms_avg_temp_c"
       ],
@@ -4115,7 +4239,7 @@
       "table": "input",
       "register": 3196,
       "register_end": 3196,
-      "type": "u16_scale10",
+      "type": "u16_percent",
       "attributes": [
         "bms_max_soc"
       ],
@@ -4128,7 +4252,7 @@
       "table": "input",
       "register": 3197,
       "register_end": 3197,
-      "type": "u16_scale10",
+      "type": "u16_percent",
       "attributes": [
         "bms_min_soc"
       ],
@@ -4141,7 +4265,7 @@
       "table": "input",
       "register": 3198,
       "register_end": 3198,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "parallel_battery_num"
       ],
@@ -4154,7 +4278,7 @@
       "table": "input",
       "register": 3199,
       "register_end": 3199,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_derate_reason"
       ],
@@ -4167,7 +4291,7 @@
       "table": "input",
       "register": 3200,
       "register_end": 3200,
-      "type": "u16_scale10",
+      "type": "u16_ampere_hour",
       "attributes": [
         "bms_gauge_fcc_ah"
       ],
@@ -4180,7 +4304,7 @@
       "table": "input",
       "register": 3201,
       "register_end": 3201,
-      "type": "u16_scale10",
+      "type": "u16_ampere_hour",
       "attributes": [
         "bms_gauge_rm_ah"
       ],
@@ -4193,7 +4317,7 @@
       "table": "input",
       "register": 3202,
       "register_end": 3202,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_protect1"
       ],
@@ -4206,7 +4330,7 @@
       "table": "input",
       "register": 3203,
       "register_end": 3203,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_warn1"
       ],
@@ -4219,7 +4343,7 @@
       "table": "input",
       "register": 3204,
       "register_end": 3204,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_fault1"
       ],
@@ -4232,7 +4356,7 @@
       "table": "input",
       "register": 3205,
       "register_end": 3205,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_fault2"
       ],
@@ -4245,7 +4369,7 @@
       "table": "input",
       "register": 3210,
       "register_end": 3210,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bat_iso_status"
       ],
@@ -4258,7 +4382,7 @@
       "table": "input",
       "register": 3211,
       "register_end": 3211,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "batt_request_flags"
       ],
@@ -4271,7 +4395,7 @@
       "table": "input",
       "register": 3212,
       "register_end": 3212,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_status"
       ],
@@ -4284,7 +4408,7 @@
       "table": "input",
       "register": 3213,
       "register_end": 3213,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_protect2"
       ],
@@ -4297,7 +4421,7 @@
       "table": "input",
       "register": 3214,
       "register_end": 3214,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_warn2"
       ],
@@ -4310,7 +4434,7 @@
       "table": "input",
       "register": 3215,
       "register_end": 3215,
-      "type": "u16_scale10",
+      "type": "u16_percent",
       "attributes": [
         "bms_soc"
       ],
@@ -4323,7 +4447,7 @@
       "table": "input",
       "register": 3216,
       "register_end": 3216,
-      "type": "u16_scale100",
+      "type": "u16_voltage_centivolt",
       "attributes": [
         "bms_battery_voltage"
       ],
@@ -4336,7 +4460,7 @@
       "table": "input",
       "register": 3217,
       "register_end": 3217,
-      "type": "u16_scale100",
+      "type": "s16_current_centiamp",
       "attributes": [
         "bms_battery_current"
       ],
@@ -4349,7 +4473,7 @@
       "table": "input",
       "register": 3218,
       "register_end": 3218,
-      "type": "u16_scale10",
+      "type": "s16_temperature_decic",
       "attributes": [
         "bms_cell_max_temp"
       ],
@@ -4362,7 +4486,7 @@
       "table": "input",
       "register": 3219,
       "register_end": 3219,
-      "type": "u16_scale100",
+      "type": "u16_current_centiamp",
       "attributes": [
         "bms_max_charge_current"
       ],
@@ -4375,7 +4499,7 @@
       "table": "input",
       "register": 3220,
       "register_end": 3220,
-      "type": "u16_scale100",
+      "type": "u16_current_centiamp",
       "attributes": [
         "bms_max_discharge_current"
       ],
@@ -4388,7 +4512,7 @@
       "table": "input",
       "register": 3221,
       "register_end": 3221,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_cycle_count"
       ],
@@ -4401,7 +4525,7 @@
       "table": "input",
       "register": 3222,
       "register_end": 3222,
-      "type": "u16_scale10",
+      "type": "u16_percent",
       "attributes": [
         "bms_soh"
       ],
@@ -4414,7 +4538,7 @@
       "table": "input",
       "register": 3223,
       "register_end": 3223,
-      "type": "u16_scale100",
+      "type": "u16_voltage_centivolt",
       "attributes": [
         "bms_charge_volt_limit"
       ],
@@ -4427,7 +4551,7 @@
       "table": "input",
       "register": 3224,
       "register_end": 3224,
-      "type": "u16_scale100",
+      "type": "u16_voltage_centivolt",
       "attributes": [
         "bms_discharge_volt_limit"
       ],
@@ -4440,7 +4564,7 @@
       "table": "input",
       "register": 3225,
       "register_end": 3225,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_warn3"
       ],
@@ -4453,7 +4577,7 @@
       "table": "input",
       "register": 3226,
       "register_end": 3226,
-      "type": "u16_scale10",
+      "type": "u16_raw",
       "attributes": [
         "bms_protect3"
       ],
@@ -4466,7 +4590,7 @@
       "table": "input",
       "register": 3230,
       "register_end": 3230,
-      "type": "u16_scale1000",
+      "type": "u16_voltage_millivolt",
       "attributes": [
         "bms_cell_volt_max"
       ],
@@ -4479,7 +4603,7 @@
       "table": "input",
       "register": 3231,
       "register_end": 3231,
-      "type": "u16_scale1000",
+      "type": "u16_voltage_millivolt",
       "attributes": [
         "bms_cell_volt_min"
       ],

--- a/doc/growatt_registers_spec.json
+++ b/doc/growatt_registers_spec.json
@@ -5039,7 +5039,6 @@
       "initial": null,
       "note": "Stored as `us_tou_month_range_block`; each word selects the start/end month and enable bit for nine slots.",
       "data_type": "us_tou_month_range_block",
-      "spec_name": "Monthly enable groups",
       "attributes": [
         "us_tou_month_groups"
       ]
@@ -5058,7 +5057,6 @@
       "initial": null,
       "note": "Stored as `us_tou_schedule_table`; each slot uses two registers (start word with enable/mode, end word with stop time and day selection).",
       "data_type": "us_tou_schedule_table",
-      "spec_name": "Time-of-use slot table",
       "attributes": [
         "us_tou_slot_table"
       ]
@@ -5077,7 +5075,6 @@
       "initial": null,
       "note": "Stored as `us_special_day_definition`; the first register enables the override and sets month/day, followed by nine optional slots.",
       "data_type": "us_special_day_definition",
-      "spec_name": "Special day 1 override",
       "attributes": [
         "us_tou_special_day_1"
       ]
@@ -5096,7 +5093,6 @@
       "initial": null,
       "note": "Stored as `us_special_day_definition`; mirrors the special day 1 layout for the second override.",
       "data_type": "us_special_day_definition",
-      "spec_name": "Special day 2 override",
       "attributes": [
         "us_tou_special_day_2"
       ]
@@ -5114,7 +5110,6 @@
       "unit": null,
       "initial": null,
       "note": "Vendor documentation marks these addresses as reserved; observed values remain zero on known firmware.",
-      "spec_name": "Reserved scheduler block",
       "attributes": [
         "us_tou_reserved_block"
       ]
@@ -5137,7 +5132,6 @@
       "initial": null,
       "note": "Repeat for additional BDCs at 40-register strides (5040–5079, 5080–5119, …). Stored as `bdc_metadata_block`.",
       "data_type": "bdc_metadata_block",
-      "spec_name": "BDC slot 1 metadata",
       "attributes": [
         "bdc_slot_1_metadata"
       ]
@@ -5146,18561 +5140,2650 @@
   "input": [
     {
       "type": "section",
-      "title": "Fi rst group"
+      "title": "Common input telemetry (0–124)"
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 0,
       "register_start": 0,
       "register_end": 0,
-      "name": "Status code",
-      "description": "Inverter run state",
-      "access": null,
-      "range": null,
+      "name": "Inverter status",
+      "description": "Operating state reported by the inverter controller (0=waiting, 1=normal, 3=fault, 5=PV charge, 6=AC charge, 7=combined charge, 8=combined charge bypass, 9=PV charge bypass, 10=AC charge bypass, 11=bypass, 12=PV charge + discharge).",
+      "access": "R",
       "unit": null,
-      "initial": null,
-      "note": null,
+      "data_type": "inverter_status_code",
       "attributes": [
         "status_code"
-      ],
-      "sensors": [
-        "Status code"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 1,
       "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "Input power (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 2,
-      "register_start": 2,
       "register_end": 2,
-      "name": "Input 2 voltage",
-      "description": "Input power (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV input power",
+      "description": "Total PV input power summed across all strings (0.1 W resolution).",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "input_2_voltage"
-      ],
-      "sensors": [
-        "Input 2 voltage",
-        "PV2 voltage"
+        "input_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 3,
       "register_start": 3,
       "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV1 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV1 DC voltage",
+      "description": "Instantaneous PV1 string voltage measured at the inverter input.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "input_1_power",
         "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 4,
       "register_start": 4,
       "register_end": 4,
-      "name": "Input 1 Amperage",
-      "description": "PV1 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV1 DC current",
+      "description": "Instantaneous PV1 string current flowing into the inverter.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
         "input_1_amperage"
-      ],
-      "sensors": [
-        "Input 1 Amperage",
-        "PV1 buck current"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 5,
       "register_start": 5,
-      "register_end": 5,
-      "name": "Input 1 Wattage",
-      "description": "PV1 input power(high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "register_end": 6,
+      "name": "PV1 DC power",
+      "description": "Real-time DC power from PV1 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "input_1_power",
-        "input_2_power"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 2 Wattage",
-        "PV1 charge power",
-        "PV2 charge power"
+        "input_1_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 6,
-      "register_start": 6,
-      "register_end": 6,
-      "name": "Ppv1 L",
-      "description": "PV1 input power(low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 7,
       "register_start": 7,
       "register_end": 7,
-      "name": "Input 1 Amperage",
-      "description": "PV2 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV2 DC voltage",
+      "description": "Instantaneous PV2 string voltage measured at the inverter input.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "input_1_amperage",
         "input_2_voltage"
-      ],
-      "sensors": [
-        "Input 1 Amperage",
-        "Input 2 voltage",
-        "PV1 buck current",
-        "PV2 voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 8,
       "register_start": 8,
       "register_end": 8,
-      "name": "Input 2 Amperage",
-      "description": "PV2 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV2 DC current",
+      "description": "Instantaneous PV2 string current flowing into the inverter.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
         "input_2_amperage"
-      ],
-      "sensors": [
-        "Input 2 Amperage",
-        "PV2 buck current"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 9,
       "register_start": 9,
-      "register_end": 9,
-      "name": "Input 2 Wattage",
-      "description": "PV2 input power (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "register_end": 10,
+      "name": "PV2 DC power",
+      "description": "Real-time DC power from PV2 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "input_2_power",
-        "output_active_power"
-      ],
-      "sensors": [
-        "Input 2 Wattage",
-        "Output active power",
-        "PV2 charge power"
+        "input_2_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": ". Ppv2 L",
-      "description": "PV2 input power (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 11,
       "register_start": 11,
       "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "PV3 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV3 DC voltage",
+      "description": "Instantaneous PV3 string voltage measured at the inverter input.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
+        "input_3_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 12,
       "register_start": 12,
       "register_end": 12,
-      "name": "Input 3 Amperage",
-      "description": "PV3 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV3 DC current",
+      "description": "Instantaneous PV3 string current flowing into the inverter.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
         "input_3_amperage"
-      ],
-      "sensors": [
-        "Input 3 Amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 13,
       "register_start": 13,
-      "register_end": 13,
-      "name": "AC frequency",
-      "description": "PV3 input power (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_power",
-        "grid_frequency",
-        "input_3_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Battery charge power",
-        "Charge Power",
-        "Grid frequency",
-        "Input 3 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 14,
-      "register_start": 14,
       "register_end": 14,
-      "name": "Output 1 voltage",
-      "description": "PV3 input power (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV3 DC power",
+      "description": "Real-time DC power from PV3 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
+        "input_3_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 15,
       "register_start": 15,
       "register_end": 15,
-      "name": "Input 4 voltage",
-      "description": "PV4 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV4 DC voltage",
+      "description": "Instantaneous PV4 string voltage measured at the inverter input.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Input 4 voltage",
-        "Output 1 Amperage",
-        "Output amperage"
+        "input_4_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 16,
       "register_start": 16,
       "register_end": 16,
-      "name": "Input 4 Amperage",
-      "description": "PV4 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV4 DC current",
+      "description": "Instantaneous PV4 string current flowing into the inverter.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "input_4_amperage",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Input 4 Amperage",
-        "Output 1 Wattage"
+        "input_4_amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 17,
       "register_start": 17,
-      "register_end": 17,
-      "name": "Battery voltage",
-      "description": "PV4 input power (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_voltage",
-        "input_4_power"
-      ],
-      "sensors": [
-        "Battery voltage",
-        "Input 4 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 18,
-      "register_start": 18,
       "register_end": 18,
-      "name": "Output 2 voltage",
-      "description": "PV4 input power (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV4 DC power",
+      "description": "Real-time DC power from PV4 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "output_2_voltage",
-        "soc"
-      ],
-      "sensors": [
-        "Output 2 voltage",
-        "SOC"
+        "input_4_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 19,
       "register_start": 19,
       "register_end": 19,
-      "name": "Bus voltage",
-      "description": "PV5 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV5 DC voltage",
+      "description": "Instantaneous PV5 string voltage measured at the inverter input.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
-      ],
-      "sensors": [
-        "Bus voltage",
-        "Input 5 voltage",
-        "Output 2 Amperage"
+        "input_5_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 20,
       "register_start": 20,
       "register_end": 20,
-      "name": "Grid voltage",
-      "description": "PV5 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV5 DC current",
+      "description": "Instantaneous PV5 string current flowing into the inverter.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
+        "input_5_amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 21,
       "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "PV5 input power(high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 22,
-      "register_start": 22,
       "register_end": 22,
-      "name": "Output 1 voltage",
-      "description": "PV5 input power(low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV5 DC power",
+      "description": "Real-time DC power from PV5 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "output_1_voltage",
-        "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output 3 voltage",
-        "Output voltage"
+        "input_5_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 23,
       "register_start": 23,
       "register_end": 23,
-      "name": "Input 6 voltage",
-      "description": "PV6 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV6 DC voltage",
+      "description": "Instantaneous PV6 string voltage measured at the inverter input.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
-      ],
-      "sensors": [
-        "Input 6 voltage",
-        "Output 3 Amperage",
-        "Output frequency"
+        "input_6_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 24,
       "register_start": 24,
       "register_end": 24,
-      "name": "Input 6 Amperage",
-      "description": "PV6 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV6 DC current",
+      "description": "Instantaneous PV6 string current flowing into the inverter.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
-      ],
-      "sensors": [
-        "Input 6 Amperage",
-        "Output 3 Wattage",
-        "Output DC voltage"
+        "input_6_amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 25,
       "register_start": 25,
-      "register_end": 25,
-      "name": "Input 6 Wattage",
-      "description": "PV6 input power (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_power",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 6 Wattage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 26,
-      "register_start": 26,
       "register_end": 26,
-      "name": "DC-DC temperature",
-      "description": "PV6 input power (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV6 DC power",
+      "description": "Real-time DC power from PV6 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "dc_dc_temperature",
-        "output_energy_today"
-      ],
-      "sensors": [
-        "DC-DC temperature",
-        "Energy produced today"
+        "input_6_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 27,
       "register_start": 27,
       "register_end": 27,
-      "name": "Input 7 voltage",
-      "description": "PV7 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV7 DC voltage",
+      "description": "Instantaneous PV7 string voltage measured at the inverter input.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "input_7_voltage",
-        "load_percent"
-      ],
-      "sensors": [
-        "Input 7 voltage",
-        "Inverter load"
+        "input_7_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 28,
       "register_start": 28,
       "register_end": 28,
-      "name": "Battery port voltage",
-      "description": "PV7 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV7 DC current",
+      "description": "Instantaneous PV7 string current flowing into the inverter.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "battery_port_voltage",
-        "input_7_amperage",
-        "output_energy_total"
-      ],
-      "sensors": [
-        "Battery port voltage",
-        "Input 7 Amperage",
-        "Total energy produced"
+        "input_7_amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 29,
       "register_start": 29,
-      "register_end": 29,
-      "name": "Battery bus voltage",
-      "description": "PV7 input power (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_bus_voltage",
-        "input_7_power"
-      ],
-      "sensors": [
-        "Battery bus voltage",
-        "Input 7 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 30,
-      "register_start": 30,
       "register_end": 30,
-      "name": "Running hours",
-      "description": "PV7 input power (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV7 DC power",
+      "description": "Real-time DC power from PV7 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "operation_hours"
-      ],
-      "sensors": [
-        "Running hours"
+        "input_7_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 31,
       "register_start": 31,
       "register_end": 31,
-      "name": "Input 8 voltage",
-      "description": "PV8 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV8 DC voltage",
+      "description": "Instantaneous PV8 string voltage measured at the inverter input.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
         "input_8_voltage"
-      ],
-      "sensors": [
-        "Input 8 voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 32,
       "register_start": 32,
       "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV8 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "PV8 DC current",
+      "description": "Instantaneous PV8 string current flowing into the inverter.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
+        "input_8_amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 33,
       "register_start": 33,
-      "register_end": 33,
-      "name": "Input 8 Wattage",
-      "description": "PV8 input power (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "register_end": 34,
+      "name": "PV8 DC power",
+      "description": "Real-time DC power from PV8 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
         "input_8_power"
-      ],
-      "sensors": [
-        "Input 8 Wattage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 34,
-      "register_start": 34,
-      "register_end": 34,
-      "name": "Output 1 Amperage",
-      "description": "PV8 input power (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Output 1 Amperage",
-        "Output amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 35,
       "register_start": 35,
-      "register_end": 35,
-      "name": "Output power",
-      "description": "Output power (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "register_end": 36,
+      "name": "AC output power",
+      "description": "Active AC output power delivered by the inverter (0.1 W resolution).",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
         "output_power"
-      ],
-      "sensors": [
-        "Output power"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 36,
-      "register_start": 36,
-      "register_end": 36,
-      "name": ". Pac L",
-      "description": "Output power (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 37,
       "register_start": 37,
       "register_end": 37,
-      "name": "AC frequency",
-      "description": "Grid frequency",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "Grid frequency",
+      "description": "Measured grid frequency with 0.01 Hz resolution.",
+      "access": "R",
+      "unit": "Hz",
+      "data_type": "u16_frequency_centihz",
       "attributes": [
         "grid_frequency"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 38,
       "register_start": 38,
       "register_end": 38,
-      "name": "Output 1 voltage",
-      "description": "Three/single phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "AC phase L1 voltage",
+      "description": "AC output voltage for phase L1.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
         "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 39,
       "register_start": 39,
       "register_end": 39,
-      "name": "Output 1 Amperage",
-      "description": "Three/single phase grid output",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "AC phase L1 current",
+      "description": "AC output current for phase L1.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
         "output_1_amperage"
-      ],
-      "sensors": [
-        "Output 1 Amperage",
-        "Output amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 40,
       "register_start": 40,
-      "register_end": 40,
-      "name": "Fault code",
-      "description": "Three/single phase grid output VA (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "fault_code",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Fault code",
-        "Output 1 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 41,
-      "register_start": 41,
       "register_end": 41,
-      "name": "Intelligent Power Management temperature",
-      "description": "Three/single phase grid output VA(low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "AC phase L1 power",
+      "description": "Active power exported on phase L1.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
+        "output_1_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 42,
       "register_start": 42,
       "register_end": 42,
-      "name": "Fault code",
-      "description": "Three phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "AC phase L2 voltage",
+      "description": "AC output voltage for phase L2.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "fault_code",
-        "output_2_voltage",
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "Fault code",
-        "Output 2 voltage",
-        "P-bus voltage"
+        "output_2_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 43,
       "register_start": 43,
       "register_end": 43,
-      "name": "N-bus voltage",
-      "description": "Three phase grid output current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "AC phase L2 current",
+      "description": "AC output current for phase L2.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "n_bus_voltage",
-        "output_2_amperage",
-        "warning_code"
-      ],
-      "sensors": [
-        "N-bus voltage",
-        "Output 2 Amperage",
-        "Warning code"
+        "output_2_amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 44,
       "register_start": 44,
-      "register_end": 44,
-      "name": "Output 2 Wattage",
-      "description": "Three phase grid output power (",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "register_end": 45,
+      "name": "AC phase L2 power",
+      "description": "Active power exported on phase L2.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
         "output_2_power"
-      ],
-      "sensors": [
-        "Output 2 Wattage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 45,
-      "register_start": 45,
-      "register_end": 45,
-      "name": ". Pac2 L",
-      "description": "Three phase grid output power (",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 46,
       "register_start": 46,
       "register_end": 46,
-      "name": "Output 3 voltage",
-      "description": "Three phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "AC phase L3 voltage",
+      "description": "AC output voltage for phase L3.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
         "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 3 voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 47,
       "register_start": 47,
       "register_end": 47,
-      "name": "Derating mode",
-      "description": "Three phase grid output current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "AC phase L3 current",
+      "description": "AC output current for phase L3.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "constant_power",
-        "derating_mode",
         "output_3_amperage"
-      ],
-      "sensors": [
-        "Derating mode",
-        "Output 3 Amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 48,
       "register_start": 48,
-      "register_end": 48,
-      "name": "Input 1 energy today",
-      "description": "Three phase grid output power (",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_energy_today",
-        "output_3_power"
-      ],
-      "sensors": [
-        "Input 1 energy today",
-        "Output 3 Wattage",
-        "PV1 energy produced today"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 49,
-      "register_start": 49,
       "register_end": 49,
-      "name": ". Pac3 L",
-      "description": "Three phase grid output power (",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 50,
-      "register_start": 50,
-      "register_end": 50,
-      "name": "Input 1 total energy",
-      "description": "Three phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": "ne voltage",
-      "initial": null,
-      "note": null,
+      "name": "AC phase L3 power",
+      "description": "Active power exported on phase L3.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "input_1_energy_total"
-      ],
-      "sensors": [
-        "Input 1 total energy",
-        "PV1 energy produced Lifetime"
+        "output_3_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 51,
-      "register_start": 51,
-      "register_end": 51,
-      "name": ". Vac_ST",
-      "description": "Three phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": "ne voltage",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 52,
-      "register_start": 52,
-      "register_end": 52,
-      "name": "Input 2 energy today",
-      "description": "Three phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": "ne voltage",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_2_energy_today"
-      ],
-      "sensors": [
-        "Input 2 energy today",
-        "PV2 energy produced today"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 53,
       "register_start": 53,
-      "register_end": 53,
-      "name": "Energy produced today",
-      "description": "Today generate energy (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "register_end": 54,
+      "name": "Output energy today",
+      "description": "Energy exported to the AC output today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "output_energy_today"
-      ],
-      "sensors": [
-        "Energy produced today"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 54,
-      "register_start": 54,
-      "register_end": 54,
-      "name": "Input 2 total energy",
-      "description": "Today generate energy (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_2_energy_total"
-      ],
-      "sensors": [
-        "Input 2 total energy",
-        "PV2 energy produced Lifetime"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 55,
       "register_start": 55,
-      "register_end": 55,
-      "name": "Total energy produced",
-      "description": "Total generate energy (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "register_end": 56,
+      "name": "Output energy total",
+      "description": "Lifetime AC output energy (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "output_energy_total"
-      ],
-      "sensors": [
-        "Total energy produced"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 56,
-      "register_start": 56,
-      "register_end": 56,
-      "name": "Battery Charged (Today)",
-      "description": "Total generate energy (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_energy_today",
-        "input_energy_total"
-      ],
-      "sensors": [
-        "Battery Charged (Today)",
-        "Battery Charged Today",
-        "Total energy input"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 57,
       "register_start": 57,
-      "register_end": 57,
-      "name": "Running hours",
-      "description": "Work time total (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "register_end": 58,
+      "name": "Run time",
+      "description": "Total cumulative run time of the inverter. Raw values are seconds scaled by 1/7200 (0.0001389 hours).",
+      "access": "R",
+      "unit": "h",
+      "data_type": "u32_runtime_hours",
+      "note": "Raw counter counts seconds; divide by 7200 to obtain hours.",
       "attributes": [
         "operation_hours"
-      ],
-      "sensors": [
-        "Running hours"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 58,
-      "register_start": 58,
-      "register_end": 58,
-      "name": "Battery Charged (Total)",
-      "description": "Work time total (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_energy_total",
-        "output_reactive_power"
-      ],
-      "sensors": [
-        "Battery Charged (Total)",
-        "Grid Charged Lifetime",
-        "Reactive wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 59,
       "register_start": 59,
-      "register_end": 59,
-      "name": "Input 1 energy today",
-      "description": "PV1Energy today(high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "register_end": 60,
+      "name": "PV1 energy today",
+      "description": "Energy harvested by PV1 today. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_1_energy_today"
-      ],
-      "sensors": [
-        "Input 1 energy today",
-        "PV1 energy produced today"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 60,
-      "register_start": 60,
-      "register_end": 60,
-      "name": "Battery Discharged (Today)",
-      "description": "PV1Energy today (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "discharge_energy_today",
-        "output_reactive_energy_today"
-      ],
-      "sensors": [
-        "Battery Discharged (Today)",
-        "Battery Discharged Today"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 61,
       "register_start": 61,
-      "register_end": 61,
-      "name": "Input 1 total energy",
-      "description": "PV1Energy total(high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "register_end": 62,
+      "name": "PV1 energy total",
+      "description": "Lifetime energy harvested by PV1. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_1_energy_total"
-      ],
-      "sensors": [
-        "Input 1 total energy",
-        "PV1 energy produced Lifetime"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 62,
-      "register_start": 62,
-      "register_end": 62,
-      "name": "Battery Discharged (Total)",
-      "description": "PV1Energy total (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "discharge_energy_total",
-        "output_reactive_energy_total"
-      ],
-      "sensors": [
-        "Battery Discharged (Total)",
-        "Battery Discharged Lifetime"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 63,
       "register_start": 63,
-      "register_end": 63,
-      "name": "Input 2 energy today",
-      "description": "PV2Energy today(high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "register_end": 64,
+      "name": "PV2 energy today",
+      "description": "Energy harvested by PV2 today. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_2_energy_today"
-      ],
-      "sensors": [
-        "Input 2 energy today",
-        "PV2 energy produced today"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 64,
-      "register_start": 64,
-      "register_end": 64,
-      "name": "AC Discharged Today",
-      "description": "PV2Energy today (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ac_discharge_energy_today",
-        "warning_code"
-      ],
-      "sensors": [
-        "AC Discharged Today",
-        "Warning code"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 65,
       "register_start": 65,
-      "register_end": 65,
-      "name": "Input 2 total energy",
-      "description": "PV2Energy total(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_2_energy_total",
-        "warning_value"
-      ],
-      "sensors": [
-        "Input 2 total energy",
-        "PV2 energy produced Lifetime"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 66,
-      "register_start": 66,
       "register_end": 66,
-      "name": "Grid Discharged Lifetime",
-      "description": "PV2Energy total (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "name": "PV2 energy total",
+      "description": "Lifetime energy harvested by PV2. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
-        "ac_discharge_energy_total",
-        "real_output_power_percent"
-      ],
-      "sensors": [
-        "Grid Discharged Lifetime",
-        "Real power output percentage"
+        "input_2_energy_total"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 67,
       "register_start": 67,
-      "register_end": 67,
-      "name": "Input 3 energy today",
-      "description": "PV3 Energy today(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 68,
+      "name": "PV3 energy today",
+      "description": "Energy harvested by PV3 today. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_3_energy_today"
-      ],
-      "sensors": [
-        "Input 3 energy today"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 68,
-      "register_start": 68,
-      "register_end": 68,
-      "name": "AC charge battery current",
-      "description": "PV3 Energy today (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ac_charge_amperage"
-      ],
-      "sensors": [
-        "AC charge battery current"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 69,
       "register_start": 69,
-      "register_end": 69,
-      "name": "Battery discharge power",
-      "description": "PV3 Energy total(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 70,
+      "name": "PV3 energy total",
+      "description": "Lifetime energy harvested by PV3. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
-        "discharge_power",
         "input_3_energy_total"
-      ],
-      "sensors": [
-        "Battery discharge power",
-        "Discharge Power",
-        "Input 3 total energy"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 70,
-      "register_start": 70,
-      "register_end": 70,
-      "name": ". Epv3_total L",
-      "description": "PV3 Energy total (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 71,
       "register_start": 71,
-      "register_end": 71,
-      "name": "Input 4 energy today",
-      "description": "PV4Energy today(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 72,
+      "name": "PV4 energy today",
+      "description": "Energy harvested by PV4 today. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_4_energy_today"
-      ],
-      "sensors": [
-        "Input 4 energy today"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 72,
-      "register_start": 72,
-      "register_end": 72,
-      "name": ". Epv4_today L",
-      "description": "PV4Energy today (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 73,
       "register_start": 73,
-      "register_end": 73,
-      "name": "Battery discharge current",
-      "description": "PV4Energy total(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 74,
+      "name": "PV4 energy total",
+      "description": "Lifetime energy harvested by PV4. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
-        "battery_discharge_amperage",
         "input_4_energy_total"
-      ],
-      "sensors": [
-        "Battery discharge current",
-        "Input 4 total energy"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 74,
-      "register_start": 74,
-      "register_end": 74,
-      "name": ". Epv4_total L",
-      "description": "PV4Energy total (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 75,
       "register_start": 75,
-      "register_end": 75,
-      "name": "Input 5 energy today",
-      "description": "PV5Energy today(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 76,
+      "name": "PV5 energy today",
+      "description": "Energy harvested by PV5 today. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_5_energy_today"
-      ],
-      "sensors": [
-        "Input 5 energy today"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 76,
-      "register_start": 76,
-      "register_end": 76,
-      "name": ". Epv5_today L",
-      "description": "PV5Energy today (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 77,
       "register_start": 77,
-      "register_end": 77,
-      "name": "Battery charging/ discharging(-ve)",
-      "description": "PV5Energy total(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 78,
+      "name": "PV5 energy total",
+      "description": "Lifetime energy harvested by PV5. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
-        "battery_power",
         "input_5_energy_total"
-      ],
-      "sensors": [
-        "Battery charging/ discharging(-ve)",
-        "Input 5 total energy"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 78,
-      "register_start": 78,
-      "register_end": 78,
-      "name": ". Epv5_total L",
-      "description": "PV5Energy total (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 79,
       "register_start": 79,
-      "register_end": 79,
-      "name": "Input 6 energy today",
-      "description": "PV6Energy today(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 80,
+      "name": "PV6 energy today",
+      "description": "Energy harvested by PV6 today. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_6_energy_today"
-      ],
-      "sensors": [
-        "Input 6 energy today"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 80,
-      "register_start": 80,
-      "register_end": 80,
-      "name": ". Epv6_today L",
-      "description": "PV6Energy today (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 81,
       "register_start": 81,
-      "register_end": 81,
-      "name": "Input 6 total energy",
-      "description": "PV6Energy total(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 82,
+      "name": "PV6 energy total",
+      "description": "Lifetime energy harvested by PV6. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_6_energy_total"
-      ],
-      "sensors": [
-        "Input 6 total energy"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 82,
-      "register_start": 82,
-      "register_end": 82,
-      "name": ". Epv6_total L",
-      "description": "PV6Energy total (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 83,
       "register_start": 83,
-      "register_end": 83,
-      "name": "Input 7 energy today",
-      "description": "PV7Energy today(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 84,
+      "name": "PV7 energy today",
+      "description": "Energy harvested by PV7 today. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_7_energy_today"
-      ],
-      "sensors": [
-        "Input 7 energy today"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 84,
-      "register_start": 84,
-      "register_end": 84,
-      "name": ". Epv7_today L",
-      "description": "PV7Energy today (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 85,
       "register_start": 85,
-      "register_end": 85,
-      "name": "Input 7 total energy",
-      "description": "PV7 Energy total(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 86,
+      "name": "PV7 energy total",
+      "description": "Lifetime energy harvested by PV7. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_7_energy_total"
-      ],
-      "sensors": [
-        "Input 7 total energy"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 86,
-      "register_start": 86,
-      "register_end": 86,
-      "name": ". Epv7_total L",
-      "description": "PV7Energy total (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 87,
       "register_start": 87,
-      "register_end": 87,
-      "name": "Input 8 energy today",
-      "description": "PV8Energy today(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 88,
+      "name": "PV8 energy today",
+      "description": "Energy harvested by PV8 today. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_8_energy_today"
-      ],
-      "sensors": [
-        "Input 8 energy today"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 88,
-      "register_start": 88,
-      "register_end": 88,
-      "name": ". Epv8_today L",
-      "description": "PV8Energy today (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 89,
       "register_start": 89,
-      "register_end": 89,
-      "name": "Input 8 total energy",
-      "description": "PV8Energy total(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 90,
+      "name": "PV8 energy total",
+      "description": "Lifetime energy harvested by PV8. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_8_energy_total"
-      ],
-      "sensors": [
-        "Input 8 total energy"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 90,
-      "register_start": 90,
-      "register_end": 90,
-      "name": ". Epv8_total L",
-      "description": "PV8Energy total (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 91,
       "register_start": 91,
-      "register_end": 91,
-      "name": "Total energy input",
-      "description": "PV Energy total(high)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
+      "register_end": 92,
+      "name": "PV energy total",
+      "description": "Total PV energy generated across all strings (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_energy_total"
-      ],
-      "sensors": [
-        "Total energy input"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 92,
-      "register_start": 92,
-      "register_end": 92,
-      "name": ". Epv_total L",
-      "description": "PV Energy total (low)",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 93,
       "register_start": 93,
       "register_end": 93,
-      "name": "Temperature",
-      "description": "Inverter temperature",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "Inverter temperature",
+      "description": "Main inverter heatsink temperature (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
       "attributes": [
         "inverter_temperature"
-      ],
-      "sensors": [
-        "Temperature"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 94,
       "register_start": 94,
       "register_end": 94,
-      "name": "Intelligent Power Management temperature",
-      "description": "The inside IPM in inverter Temp",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "name": "IPM temperature",
+      "description": "IPM (power module) temperature (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
       "attributes": [
         "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 95,
       "register_start": 95,
       "register_end": 95,
       "name": "Boost temperature",
-      "description": "Boost temperature",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "description": "Boost inductor temperature (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
       "attributes": [
         "boost_temperature"
-      ],
-      "sensors": [
-        "Boost temperature"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 96,
-      "register_start": 96,
-      "register_end": 96,
-      "name": ". Temp4",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "reserved",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 97,
-      "register_start": 97,
-      "register_end": 97,
-      "name": ". uwBatVolt_DSP",
-      "description": "BatVolt_DSP",
-      "access": null,
-      "range": null,
-      "unit": "BatVolt(DSP)",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 98,
       "register_start": 98,
       "register_end": 98,
       "name": "P-bus voltage",
-      "description": "P Bus inside Voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "description": "Positive DC bus voltage (0.1 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
         "p_bus_voltage"
-      ],
-      "sensors": [
-        "P-bus voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
+      "section": "Common input telemetry (0–124)",
       "register": 99,
       "register_start": 99,
       "register_end": 99,
       "name": "N-bus voltage",
-      "description": "N Bus inside Voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "description": "Negative DC bus voltage (0.1 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
         "n_bus_voltage"
-      ],
-      "sensors": [
-        "N-bus voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "0. IPF",
-      "description": "Inverter output PF now",
-      "access": null,
-      "range": null,
+      "section": "Common input telemetry (0–124)",
+      "register": 101,
+      "register_start": 101,
+      "register_end": 101,
+      "name": "Output power percentage",
+      "description": "Instantaneous AC output as a percentage of the inverter's rated power.",
+      "access": "R",
+      "unit": "%",
+      "data_type": "u16_percent",
+      "attributes": [
+        "real_output_power_percent"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "Common input telemetry (0–124)",
+      "register": 104,
+      "register_start": 104,
+      "register_end": 104,
+      "name": "Derating mode",
+      "description": "Active derating reason reported by the inverter controller.",
+      "access": "R",
       "unit": null,
-      "initial": null,
-      "note": null
+      "data_type": "u16_raw_code",
+      "attributes": [
+        "derating_mode"
+      ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "1. RealOPPercent",
-      "description": "Real Output power Percent",
-      "access": null,
-      "range": null,
+      "section": "Common input telemetry (0–124)",
+      "register": 105,
+      "register_start": 105,
+      "register_end": 105,
+      "name": "Fault code",
+      "description": "Current inverter fault code (see protocol documentation).",
+      "access": "R",
       "unit": null,
-      "initial": null,
-      "note": null
+      "data_type": "u16_status_word",
+      "attributes": [
+        "fault_code"
+      ]
     },
     {
       "type": "entry",
-      "section": "Fi rst group",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "2. OPFullwatt H",
-      "description": "Output Maxpower Limited high",
-      "access": null,
-      "range": null,
+      "section": "Common input telemetry (0–124)",
+      "register": 110,
+      "register_start": 110,
+      "register_end": 111,
+      "name": "Warning code",
+      "description": "Current inverter warning code (vendor-defined bitmask).",
+      "access": "R",
       "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "3. OPFullwatt L",
-      "description": "Output Maxpower Limited low",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "4. DeratingMode",
-      "description": "DeratingMode 0 1 2 3 4 5 6 7 8 9 B",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "5. Fault Maincode",
-      "description": "Inverter fault maincode",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "6.",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "7. Fault Subcode",
-      "description": "Inverter fault subcode",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "8. RemoteCtrlEn",
-      "description": "/ 0 1",
-      "access": null,
-      "range": null,
-      "unit": "oragePow (SPA)",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "9. RemoteCtrlPow er",
-      "description": "/ 2",
-      "access": null,
-      "range": null,
-      "unit": "oragePow (SPA)",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Warning bit H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "data_type": "u16_status_word",
       "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Inverter warn subcode",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Inverter warn maincode ACCharge energy today",
-      "access": null,
-      "range": null,
-      "unit": "orage wer",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "real Power Percent 0 ACCharge energy today",
-      "access": null,
-      "range": null,
-      "unit": "X orage wer",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "nv start delay time ACCharge energy total",
-      "access": null,
-      "range": null,
-      "unit": "X orage wer",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "bINVAllFaultCode ACCharge energy total",
-      "access": null,
-      "range": null,
-      "unit": "X orage wer",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Grid power to local load",
-      "access": null,
-      "range": null,
-      "unit": "orage wer",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Grid power to local load",
-      "access": null,
-      "range": null,
-      "unit": "orage wer",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "0:Load First 1:Battery First 2:Grid First",
-      "access": null,
-      "range": null,
-      "unit": "orage Power",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "0:Lead-acid 1:Lithium battery",
-      "access": null,
-      "range": null,
-      "unit": "Storage Power",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Fi rst group",
-      "register": 12,
-      "register_start": 12,
-      "register_end": 12,
-      "name": "Input 3 Amperage",
-      "description": "Aging mode Auto-cal command",
-      "access": null,
-      "range": null,
-      "unit": "Storage Power",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_amperage"
-      ],
-      "sensors": [
-        "Input 3 Amperage"
+        "warning_code"
       ]
     },
     {
       "type": "section",
-      "title": "… reserved reserved"
+      "title": "Extended common input telemetry (125–299)"
     },
     {
       "type": "entry",
-      "section": "… reserved reserved",
-      "register": 12,
-      "register_start": 12,
-      "register_end": 12,
-      "name": "Input 3 Amperage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "reserved",
-      "initial": null,
-      "note": null,
+      "section": "Extended common input telemetry (125–299)",
+      "register": 234,
+      "register_start": 234,
+      "register_end": 235,
+      "name": "Output reactive power",
+      "description": "Instantaneous reactive power on the AC output (positive = inductive, negative = capacitive).",
+      "access": "R",
+      "unit": "var",
+      "data_type": "s32_reactive_power_decivar",
       "attributes": [
-        "input_3_amperage"
-      ],
-      "sensors": [
-        "Input 3 Amperage"
+        "output_reactive_power"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "Extended common input telemetry (125–299)",
+      "register": 236,
+      "register_start": 236,
+      "register_end": 237,
+      "name": "Reactive energy total",
+      "description": "Lifetime accumulated reactive energy (0.1 kvarh resolution).",
+      "access": "R",
+      "unit": "kvarh",
+      "data_type": "u32_energy_kvarh_decitenth",
+      "attributes": [
+        "output_reactive_energy_total"
       ]
     },
     {
       "type": "section",
-      "title": "Se cond group"
+      "title": "TL-X/TL-XH PV/AC telemetry (3000–3124)"
     },
     {
       "type": "entry",
-      "section": "Se cond group",
-      "register": 12,
-      "register_start": 12,
-      "register_end": 12,
-      "name": "Input 3 Amperage",
-      "description": "PID PV1PE Volt/ Flyspan volta (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": "V",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_amperage"
-      ],
-      "sensors": [
-        "Input 3 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 12,
-      "register_start": 12,
-      "register_end": 12,
-      "name": "Input 3 Amperage",
-      "description": "PID PV1PE Curr",
-      "access": null,
-      "range": null,
-      "unit": "mA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_amperage"
-      ],
-      "sensors": [
-        "Input 3 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 12,
-      "register_start": 12,
-      "register_end": 12,
-      "name": "Input 3 Amperage",
-      "description": "PID PV2PE Volt/ Flyspan volta (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": "V",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_amperage"
-      ],
-      "sensors": [
-        "Input 3 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 12,
-      "register_start": 12,
-      "register_end": 12,
-      "name": "Input 3 Amperage",
-      "description": "PID PV2PE Curr",
-      "access": null,
-      "range": null,
-      "unit": "mA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_amperage"
-      ],
-      "sensors": [
-        "Input 3 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 12,
-      "register_start": 12,
-      "register_end": 12,
-      "name": "Input 3 Amperage",
-      "description": "PID PV3PE Volt/ Flyspan volta (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": "V",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_amperage"
-      ],
-      "sensors": [
-        "Input 3 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 13,
-      "register_start": 13,
-      "register_end": 13,
-      "name": "AC frequency",
-      "description": "PID PV3PE Curr",
-      "access": null,
-      "range": null,
-      "unit": "mA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_power",
-        "grid_frequency",
-        "input_3_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Battery charge power",
-        "Charge Power",
-        "Grid frequency",
-        "Input 3 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 13,
-      "register_start": 13,
-      "register_end": 13,
-      "name": "AC frequency",
-      "description": "PID PV4PE Volt/ Flyspan volta (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": "V",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_power",
-        "grid_frequency",
-        "input_3_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Battery charge power",
-        "Charge Power",
-        "Grid frequency",
-        "Input 3 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 13,
-      "register_start": 13,
-      "register_end": 13,
-      "name": "AC frequency",
-      "description": "PID PV4PE Curr",
-      "access": null,
-      "range": null,
-      "unit": "mA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_power",
-        "grid_frequency",
-        "input_3_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Battery charge power",
-        "Charge Power",
-        "Grid frequency",
-        "Input 3 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 13,
-      "register_start": 13,
-      "register_end": 13,
-      "name": "AC frequency",
-      "description": "PID PV5PE Volt/ Flyspan volta (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": "V",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_power",
-        "grid_frequency",
-        "input_3_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Battery charge power",
-        "Charge Power",
-        "Grid frequency",
-        "Input 3 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 13,
-      "register_start": 13,
-      "register_end": 13,
-      "name": "AC frequency",
-      "description": "PID PV5PE Curr",
-      "access": null,
-      "range": null,
-      "unit": "mA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_power",
-        "grid_frequency",
-        "input_3_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Battery charge power",
-        "Charge Power",
-        "Grid frequency",
-        "Input 3 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 13,
-      "register_start": 13,
-      "register_end": 13,
-      "name": "AC frequency",
-      "description": "PID PV6PE Volt/ Flyspan volta (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": "V",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_power",
-        "grid_frequency",
-        "input_3_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Battery charge power",
-        "Charge Power",
-        "Grid frequency",
-        "Input 3 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 13,
-      "register_start": 13,
-      "register_end": 13,
-      "name": "AC frequency",
-      "description": "PID PV6PE Curr",
-      "access": null,
-      "range": null,
-      "unit": "mA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_power",
-        "grid_frequency",
-        "input_3_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Battery charge power",
-        "Charge Power",
-        "Grid frequency",
-        "Input 3 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 13,
-      "register_start": 13,
-      "register_end": 13,
-      "name": "AC frequency",
-      "description": "PID PV7PE Volt/ Flyspan volta (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": "V",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_power",
-        "grid_frequency",
-        "input_3_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Battery charge power",
-        "Charge Power",
-        "Grid frequency",
-        "Input 3 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 13,
-      "register_start": 13,
-      "register_end": 13,
-      "name": "AC frequency",
-      "description": "PID PV7PE Curr",
-      "access": null,
-      "range": null,
-      "unit": "mA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_power",
-        "grid_frequency",
-        "input_3_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Battery charge power",
-        "Charge Power",
-        "Grid frequency",
-        "Input 3 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 13,
-      "register_start": 13,
-      "register_end": 13,
-      "name": "AC frequency",
-      "description": "PID PV8PE Volt/ Flyspan volta (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": "V",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "charge_power",
-        "grid_frequency",
-        "input_3_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Battery charge power",
-        "Charge Power",
-        "Grid frequency",
-        "Input 3 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 14,
-      "register_start": 14,
-      "register_end": 14,
-      "name": "Output 1 voltage",
-      "description": "PID PV8PE Curr",
-      "access": null,
-      "range": null,
-      "unit": "mA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 14,
-      "register_start": 14,
-      "register_end": 14,
-      "name": "Output 1 voltage",
-      "description": "Bit0~7:PID Working Status 1:Wait Status 2:Normal Status 3:Fault Status Bit8~15:Reversed",
-      "access": null,
-      "range": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3000,
+      "register_start": 3000,
+      "register_end": 3000,
+      "name": "Inverter status",
+      "description": "Operating state reported by the inverter controller (0=waiting, 1=normal, 3=fault, 5=PV charge, 6=AC charge, 7=combined charge, 8=combined charge bypass, 9=PV charge bypass, 10=AC charge bypass, 11=bypass, 12=PV charge + discharge).",
+      "access": "R",
       "unit": null,
-      "initial": null,
-      "note": null,
+      "data_type": "inverter_status_code",
       "attributes": [
-        "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
+        "status_code"
       ]
     },
     {
       "type": "entry",
-      "section": "Se cond group",
-      "register": 14,
-      "register_start": 14,
-      "register_end": 14,
-      "name": "Output 1 voltage",
-      "description": "PV String1 voltage",
-      "access": null,
-      "range": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3001,
+      "register_start": 3001,
+      "register_end": 3002,
+      "name": "PV input power",
+      "description": "Total PV input power summed across all strings (0.1 W resolution).",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
+      "attributes": [
+        "input_power"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3003,
+      "register_start": 3003,
+      "register_end": 3003,
+      "name": "PV1 DC voltage",
+      "description": "Instantaneous PV1 string voltage measured at the inverter input.",
+      "access": "R",
       "unit": "V",
-      "initial": null,
-      "note": null,
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
+        "input_1_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Se cond group",
-      "register": 14,
-      "register_start": 14,
-      "register_end": 14,
-      "name": "Output 1 voltage",
-      "description": "PV String1 current",
-      "access": null,
-      "range": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3004,
+      "register_start": 3004,
+      "register_end": 3004,
+      "name": "PV1 DC current",
+      "description": "Instantaneous PV1 string current flowing into the inverter.",
+      "access": "R",
       "unit": "A",
-      "initial": null,
-      "note": null,
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
+        "input_1_amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Se cond group",
-      "register": 14,
-      "register_start": 14,
-      "register_end": 14,
-      "name": "Output 1 voltage",
-      "description": "PV String2 voltage",
-      "access": null,
-      "range": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3005,
+      "register_start": 3005,
+      "register_end": 3006,
+      "name": "PV1 DC power",
+      "description": "Real-time DC power from PV1 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
+      "attributes": [
+        "input_1_power"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3007,
+      "register_start": 3007,
+      "register_end": 3007,
+      "name": "PV2 DC voltage",
+      "description": "Instantaneous PV2 string voltage measured at the inverter input.",
+      "access": "R",
       "unit": "V",
-      "initial": null,
-      "note": null,
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
+        "input_2_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Se cond group",
-      "register": 14,
-      "register_start": 14,
-      "register_end": 14,
-      "name": "Output 1 voltage",
-      "description": "PV String2 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3008,
+      "register_start": 3008,
+      "register_end": 3008,
+      "name": "PV2 DC current",
+      "description": "Instantaneous PV2 string current flowing into the inverter.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
+        "input_2_amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Se cond group",
-      "register": 14,
-      "register_start": 14,
-      "register_end": 14,
-      "name": "Output 1 voltage",
-      "description": "PV String3 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3009,
+      "register_start": 3009,
+      "register_end": 3010,
+      "name": "PV2 DC power",
+      "description": "Real-time DC power from PV2 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
+        "input_2_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Se cond group",
-      "register": 14,
-      "register_start": 14,
-      "register_end": 14,
-      "name": "Output 1 voltage",
-      "description": "PV String3 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3011,
+      "register_start": 3011,
+      "register_end": 3011,
+      "name": "PV3 DC voltage",
+      "description": "Instantaneous PV3 string voltage measured at the inverter input.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
+        "input_3_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Se cond group",
-      "register": 14,
-      "register_start": 14,
-      "register_end": 14,
-      "name": "Output 1 voltage",
-      "description": "PV String4 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 14,
-      "register_start": 14,
-      "register_end": 14,
-      "name": "Output 1 voltage",
-      "description": "PV String4 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 15,
-      "register_start": 15,
-      "register_end": 15,
-      "name": "Input 4 voltage",
-      "description": "PV String5 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Input 4 voltage",
-        "Output 1 Amperage",
-        "Output amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 15,
-      "register_start": 15,
-      "register_end": 15,
-      "name": "Input 4 voltage",
-      "description": "PV String5 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Input 4 voltage",
-        "Output 1 Amperage",
-        "Output amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 15,
-      "register_start": 15,
-      "register_end": 15,
-      "name": "Input 4 voltage",
-      "description": "PV String6 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Input 4 voltage",
-        "Output 1 Amperage",
-        "Output amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 15,
-      "register_start": 15,
-      "register_end": 15,
-      "name": "Input 4 voltage",
-      "description": "PV String6 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Input 4 voltage",
-        "Output 1 Amperage",
-        "Output amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 15,
-      "register_start": 15,
-      "register_end": 15,
-      "name": "Input 4 voltage",
-      "description": "PV String7 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Input 4 voltage",
-        "Output 1 Amperage",
-        "Output amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 15,
-      "register_start": 15,
-      "register_end": 15,
-      "name": "Input 4 voltage",
-      "description": "PV String7 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Input 4 voltage",
-        "Output 1 Amperage",
-        "Output amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 15,
-      "register_start": 15,
-      "register_end": 15,
-      "name": "Input 4 voltage",
-      "description": "PV String8 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Input 4 voltage",
-        "Output 1 Amperage",
-        "Output amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 15,
-      "register_start": 15,
-      "register_end": 15,
-      "name": "Input 4 voltage",
-      "description": "PV String8 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Input 4 voltage",
-        "Output 1 Amperage",
-        "Output amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 15,
-      "register_start": 15,
-      "register_end": 15,
-      "name": "Input 4 voltage",
-      "description": "PV String9 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Input 4 voltage",
-        "Output 1 Amperage",
-        "Output amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 15,
-      "register_start": 15,
-      "register_end": 15,
-      "name": "Input 4 voltage",
-      "description": "PV String9 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_voltage",
-        "output_1_amperage"
-      ],
-      "sensors": [
-        "Input 4 voltage",
-        "Output 1 Amperage",
-        "Output amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 16,
-      "register_start": 16,
-      "register_end": 16,
-      "name": "Input 4 Amperage",
-      "description": "PV String10 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_amperage",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Input 4 Amperage",
-        "Output 1 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 16,
-      "register_start": 16,
-      "register_end": 16,
-      "name": "Input 4 Amperage",
-      "description": "PV String10 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_amperage",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Input 4 Amperage",
-        "Output 1 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 16,
-      "register_start": 16,
-      "register_end": 16,
-      "name": "Input 4 Amperage",
-      "description": "PV String11 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_amperage",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Input 4 Amperage",
-        "Output 1 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 16,
-      "register_start": 16,
-      "register_end": 16,
-      "name": "Input 4 Amperage",
-      "description": "PV String11 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_amperage",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Input 4 Amperage",
-        "Output 1 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 16,
-      "register_start": 16,
-      "register_end": 16,
-      "name": "Input 4 Amperage",
-      "description": "PV String12 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_amperage",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Input 4 Amperage",
-        "Output 1 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 16,
-      "register_start": 16,
-      "register_end": 16,
-      "name": "Input 4 Amperage",
-      "description": "PV String12 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_amperage",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Input 4 Amperage",
-        "Output 1 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 16,
-      "register_start": 16,
-      "register_end": 16,
-      "name": "Input 4 Amperage",
-      "description": "PV String13 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_amperage",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Input 4 Amperage",
-        "Output 1 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 16,
-      "register_start": 16,
-      "register_end": 16,
-      "name": "Input 4 Amperage",
-      "description": "PV String13 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_amperage",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Input 4 Amperage",
-        "Output 1 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 16,
-      "register_start": 16,
-      "register_end": 16,
-      "name": "Input 4 Amperage",
-      "description": "PV String14 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_amperage",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Input 4 Amperage",
-        "Output 1 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 16,
-      "register_start": 16,
-      "register_end": 16,
-      "name": "Input 4 Amperage",
-      "description": "PV String14 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_4_amperage",
-        "output_1_power"
-      ],
-      "sensors": [
-        "Input 4 Amperage",
-        "Output 1 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 17,
-      "register_start": 17,
-      "register_end": 17,
-      "name": "Battery voltage",
-      "description": "PV String15 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_voltage",
-        "input_4_power"
-      ],
-      "sensors": [
-        "Battery voltage",
-        "Input 4 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 17,
-      "register_start": 17,
-      "register_end": 17,
-      "name": "Battery voltage",
-      "description": "PV String15 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_voltage",
-        "input_4_power"
-      ],
-      "sensors": [
-        "Battery voltage",
-        "Input 4 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 17,
-      "register_start": 17,
-      "register_end": 17,
-      "name": "Battery voltage",
-      "description": "PV String16 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_voltage",
-        "input_4_power"
-      ],
-      "sensors": [
-        "Battery voltage",
-        "Input 4 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 17,
-      "register_start": 17,
-      "register_end": 17,
-      "name": "Battery voltage",
-      "description": "PV String16 current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_voltage",
-        "input_4_power"
-      ],
-      "sensors": [
-        "Battery voltage",
-        "Input 4 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 17,
-      "register_start": 17,
-      "register_end": 17,
-      "name": "Battery voltage",
-      "description": "Bit0~15: String1~16 unmatch",
-      "access": null,
-      "range": null,
-      "unit": "suggestive",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_voltage",
-        "input_4_power"
-      ],
-      "sensors": [
-        "Battery voltage",
-        "Input 4 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 17,
-      "register_start": 17,
-      "register_end": 17,
-      "name": "Battery voltage",
-      "description": "Bit0~15: String1~16 current u",
-      "access": null,
-      "range": null,
-      "unit": "suggestive",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_voltage",
-        "input_4_power"
-      ],
-      "sensors": [
-        "Battery voltage",
-        "Input 4 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 17,
-      "register_start": 17,
-      "register_end": 17,
-      "name": "Battery voltage",
-      "description": "Bit0~15: String1~16 disconnec",
-      "access": null,
-      "range": null,
-      "unit": "suggestive",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_voltage",
-        "input_4_power"
-      ],
-      "sensors": [
-        "Battery voltage",
-        "Input 4 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 17,
-      "register_start": 17,
-      "register_end": 17,
-      "name": "Battery voltage",
-      "description": "Bit0:Output over voltage Bit1: ISO fault Bit2: BUS voltage abnormal Bit3~15:reserved",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_voltage",
-        "input_4_power"
-      ],
-      "sensors": [
-        "Battery voltage",
-        "Input 4 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 17,
-      "register_start": 17,
-      "register_end": 17,
-      "name": "Battery voltage",
-      "description": "String Prompt Bit0:String Unmatch Bit1:StrDisconnect Bit2:StrCurrentUnblance Bit3~15:reserved",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_voltage",
-        "input_4_power"
-      ],
-      "sensors": [
-        "Battery voltage",
-        "Input 4 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 17,
-      "register_start": 17,
-      "register_end": 17,
-      "name": "Battery voltage",
-      "description": "PV Warning Value",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "battery_voltage",
-        "input_4_power"
-      ],
-      "sensors": [
-        "Battery voltage",
-        "Input 4 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 18,
-      "register_start": 18,
-      "register_end": 18,
-      "name": "Output 2 voltage",
-      "description": "DSP075 Warning Value",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_2_voltage",
-        "soc"
-      ],
-      "sensors": [
-        "Output 2 voltage",
-        "SOC"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 18,
-      "register_start": 18,
-      "register_end": 18,
-      "name": "Output 2 voltage",
-      "description": "ult DSP075 Fault Value",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_2_voltage",
-        "soc"
-      ],
-      "sensors": [
-        "Output 2 voltage",
-        "SOC"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 18,
-      "register_start": 18,
-      "register_end": 18,
-      "name": "Output 2 voltage",
-      "description": "g DSP067 Debug Data1",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_2_voltage",
-        "soc"
-      ],
-      "sensors": [
-        "Output 2 voltage",
-        "SOC"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 18,
-      "register_start": 18,
-      "register_end": 18,
-      "name": "Output 2 voltage",
-      "description": "g DSP067 Debug Data2",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_2_voltage",
-        "soc"
-      ],
-      "sensors": [
-        "Output 2 voltage",
-        "SOC"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 18,
-      "register_start": 18,
-      "register_end": 18,
-      "name": "Output 2 voltage",
-      "description": "g DSP067 Debug Data3",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_2_voltage",
-        "soc"
-      ],
-      "sensors": [
-        "Output 2 voltage",
-        "SOC"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 18,
-      "register_start": 18,
-      "register_end": 18,
-      "name": "Output 2 voltage",
-      "description": "g DSP067 Debug Data4",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_2_voltage",
-        "soc"
-      ],
-      "sensors": [
-        "Output 2 voltage",
-        "SOC"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 18,
-      "register_start": 18,
-      "register_end": 18,
-      "name": "Output 2 voltage",
-      "description": "g DSP067 Debug Data5",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_2_voltage",
-        "soc"
-      ],
-      "sensors": [
-        "Output 2 voltage",
-        "SOC"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 18,
-      "register_start": 18,
-      "register_end": 18,
-      "name": "Output 2 voltage",
-      "description": "g DSP067 Debug Data6",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_2_voltage",
-        "soc"
-      ],
-      "sensors": [
-        "Output 2 voltage",
-        "SOC"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 18,
-      "register_start": 18,
-      "register_end": 18,
-      "name": "Output 2 voltage",
-      "description": "g DSP067 Debug Data7",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_2_voltage",
-        "soc"
-      ],
-      "sensors": [
-        "Output 2 voltage",
-        "SOC"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 18,
-      "register_start": 18,
-      "register_end": 18,
-      "name": "Output 2 voltage",
-      "description": "g DSP067 Debug Data8",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_2_voltage",
-        "soc"
-      ],
-      "sensors": [
-        "Output 2 voltage",
-        "SOC"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 19,
-      "register_start": 19,
-      "register_end": 19,
-      "name": "Bus voltage",
-      "description": "g DSP075 Debug Data1",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
-      ],
-      "sensors": [
-        "Bus voltage",
-        "Input 5 voltage",
-        "Output 2 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 19,
-      "register_start": 19,
-      "register_end": 19,
-      "name": "Bus voltage",
-      "description": "g DSP075 Debug Data2",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
-      ],
-      "sensors": [
-        "Bus voltage",
-        "Input 5 voltage",
-        "Output 2 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 19,
-      "register_start": 19,
-      "register_end": 19,
-      "name": "Bus voltage",
-      "description": "g DSP075 Debug Data3",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
-      ],
-      "sensors": [
-        "Bus voltage",
-        "Input 5 voltage",
-        "Output 2 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 19,
-      "register_start": 19,
-      "register_end": 19,
-      "name": "Bus voltage",
-      "description": "g DSP075 Debug Data4",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
-      ],
-      "sensors": [
-        "Bus voltage",
-        "Input 5 voltage",
-        "Output 2 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 19,
-      "register_start": 19,
-      "register_end": 19,
-      "name": "Bus voltage",
-      "description": "g DSP075 Debug Data5",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
-      ],
-      "sensors": [
-        "Bus voltage",
-        "Input 5 voltage",
-        "Output 2 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 19,
-      "register_start": 19,
-      "register_end": 19,
-      "name": "Bus voltage",
-      "description": "g DSP075 Debug Data6",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
-      ],
-      "sensors": [
-        "Bus voltage",
-        "Input 5 voltage",
-        "Output 2 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 19,
-      "register_start": 19,
-      "register_end": 19,
-      "name": "Bus voltage",
-      "description": "g DSP075 Debug Data7",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
-      ],
-      "sensors": [
-        "Bus voltage",
-        "Input 5 voltage",
-        "Output 2 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 19,
-      "register_start": 19,
-      "register_end": 19,
-      "name": "Bus voltage",
-      "description": "g DSP075 Debug Data8",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
-      ],
-      "sensors": [
-        "Bus voltage",
-        "Input 5 voltage",
-        "Output 2 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 19,
-      "register_start": 19,
-      "register_end": 19,
-      "name": "Bus voltage",
-      "description": "USBAgingTestOkFlag 0-1",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
-      ],
-      "sensors": [
-        "Bus voltage",
-        "Input 5 voltage",
-        "Output 2 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 19,
-      "register_start": 19,
-      "register_end": 19,
-      "name": "Bus voltage",
-      "description": "FlashEraseAgingOkFlag 0-1",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "bus_voltage",
-        "input_5_voltage",
-        "output_2_amperage"
-      ],
-      "sensors": [
-        "Bus voltage",
-        "Input 5 voltage",
-        "Output 2 Amperage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "PVISOValue",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "R DCI Curr",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "S DCI Curr",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "T DCI Curr",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "PIDBusVolt",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "GFCI Curr",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "SVG/APF Status+SVGAPFEqualRat",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "R phase load side current for",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "S phase load side current for",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "T phase load side current for",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "R phase load side output reac power for SVG(High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "R phase load side output reac power for SVG(low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "S phase load side output reac power for SVG(High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "S phase load side output reac power for SVG(low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "T phase load side output reac power for SVG(High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "T phase load side output reac power for SVG(low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "R phase load side harmonic",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "S phase load side harmonic",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "T phase load side harmonic",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "R phase compensate reactive p for SVG(High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 22,
-      "register_start": 22,
-      "register_end": 22,
-      "name": "Output 1 voltage",
-      "description": "R phase compensate reactive p for SVG(low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage",
-        "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output 3 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 22,
-      "register_start": 22,
-      "register_end": 22,
-      "name": "Output 1 voltage",
-      "description": "S phase compensate reactive p for SVG(High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage",
-        "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output 3 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 22,
-      "register_start": 22,
-      "register_end": 22,
-      "name": "Output 1 voltage",
-      "description": "S phase compensate reactive p for SVG(low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage",
-        "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output 3 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 22,
-      "register_start": 22,
-      "register_end": 22,
-      "name": "Output 1 voltage",
-      "description": "T phase compensate reactive p for SVG(High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage",
-        "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output 3 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 22,
-      "register_start": 22,
-      "register_end": 22,
-      "name": "Output 1 voltage",
-      "description": "T phase compensate reactive p for SVG(low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage",
-        "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output 3 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 22,
-      "register_start": 22,
-      "register_end": 22,
-      "name": "Output 1 voltage",
-      "description": "R phase compensate harmonic f SVG",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage",
-        "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output 3 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 22,
-      "register_start": 22,
-      "register_end": 22,
-      "name": "Output 1 voltage",
-      "description": "S phase compensate harmonic f SVG",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage",
-        "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output 3 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 22,
-      "register_start": 22,
-      "register_end": 22,
-      "name": "Output 1 voltage",
-      "description": "T phase compensate harmonic f SVG",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage",
-        "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output 3 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 22,
-      "register_start": 22,
-      "register_end": 22,
-      "name": "Output 1 voltage",
-      "description": "RS232AgingTestOkFlag",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage",
-        "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output 3 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 22,
-      "register_start": 22,
-      "register_end": 22,
-      "name": "Output 1 voltage",
-      "description": "Bit0: Fan 1 fault bit Bit1: Fan 2 fault bit Bit2: Fan 3 fault bit Bit3: Fan 4 fault bit Bit4-7: Reserved",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "output_1_voltage",
-        "output_3_voltage"
-      ],
-      "sensors": [
-        "Output 1 voltage",
-        "Output 3 voltage",
-        "Output voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 23,
-      "register_start": 23,
-      "register_end": 23,
-      "name": "Input 6 voltage",
-      "description": "Output apparent power H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
-      ],
-      "sensors": [
-        "Input 6 voltage",
-        "Output 3 Amperage",
-        "Output frequency"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 23,
-      "register_start": 23,
-      "register_end": 23,
-      "name": "Input 6 voltage",
-      "description": "Output apparent power L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
-      ],
-      "sensors": [
-        "Input 6 voltage",
-        "Output 3 Amperage",
-        "Output frequency"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 23,
-      "register_start": 23,
-      "register_end": 23,
-      "name": "Input 6 voltage",
-      "description": "Real Output Reactive Power H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
-      ],
-      "sensors": [
-        "Input 6 voltage",
-        "Output 3 Amperage",
-        "Output frequency"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 23,
-      "register_start": 23,
-      "register_end": 23,
-      "name": "Input 6 voltage",
-      "description": "Real Output Reactive Power L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
-      ],
-      "sensors": [
-        "Input 6 voltage",
-        "Output 3 Amperage",
-        "Output frequency"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 23,
-      "register_start": 23,
-      "register_end": 23,
-      "name": "Input 6 voltage",
-      "description": "Nominal Output Reactive Power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
-      ],
-      "sensors": [
-        "Input 6 voltage",
-        "Output 3 Amperage",
-        "Output frequency"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 23,
-      "register_start": 23,
-      "register_end": 23,
-      "name": "Input 6 voltage",
-      "description": "Nominal Output Reactive Power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
-      ],
-      "sensors": [
-        "Input 6 voltage",
-        "Output 3 Amperage",
-        "Output frequency"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 23,
-      "register_start": 23,
-      "register_end": 23,
-      "name": "Input 6 voltage",
-      "description": "Reactive power generation",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
-      ],
-      "sensors": [
-        "Input 6 voltage",
-        "Output 3 Amperage",
-        "Output frequency"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 23,
-      "register_start": 23,
-      "register_end": 23,
-      "name": "Input 6 voltage",
-      "description": "Reactive power generation",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
-      ],
-      "sensors": [
-        "Input 6 voltage",
-        "Output 3 Amperage",
-        "Output frequency"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 23,
-      "register_start": 23,
-      "register_end": 23,
-      "name": "Input 6 voltage",
-      "description": "0:Waiting 1:Self-check state 2:Detect pull arc state 3:Fault 4:Update",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
-      ],
-      "sensors": [
-        "Input 6 voltage",
-        "Output 3 Amperage",
-        "Output frequency"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 23,
-      "register_start": 23,
-      "register_end": 23,
-      "name": "Input 6 voltage",
-      "description": "PresentFFTValue [CHANNEL_A]",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_voltage",
-        "output_3_amperage",
-        "output_frequency"
-      ],
-      "sensors": [
-        "Input 6 voltage",
-        "Output 3 Amperage",
-        "Output frequency"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 24,
-      "register_start": 24,
-      "register_end": 24,
-      "name": "Input 6 Amperage",
-      "description": "PresentFFTValue [CHANNEL_B]",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
-      ],
-      "sensors": [
-        "Input 6 Amperage",
-        "Output 3 Wattage",
-        "Output DC voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 24,
-      "register_start": 24,
-      "register_end": 24,
-      "name": "Input 6 Amperage",
-      "description": "ug DSP067 Debug Data1",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
-      ],
-      "sensors": [
-        "Input 6 Amperage",
-        "Output 3 Wattage",
-        "Output DC voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 24,
-      "register_start": 24,
-      "register_end": 24,
-      "name": "Input 6 Amperage",
-      "description": "ug DSP067 Debug Data2",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
-      ],
-      "sensors": [
-        "Input 6 Amperage",
-        "Output 3 Wattage",
-        "Output DC voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 24,
-      "register_start": 24,
-      "register_end": 24,
-      "name": "Input 6 Amperage",
-      "description": "ug DSP067 Debug Data3",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
-      ],
-      "sensors": [
-        "Input 6 Amperage",
-        "Output 3 Wattage",
-        "Output DC voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 24,
-      "register_start": 24,
-      "register_end": 24,
-      "name": "Input 6 Amperage",
-      "description": "g DSP067 Debug Data4",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
-      ],
-      "sensors": [
-        "Input 6 Amperage",
-        "Output 3 Wattage",
-        "Output DC voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 24,
-      "register_start": 24,
-      "register_end": 24,
-      "name": "Input 6 Amperage",
-      "description": "g DSP067 Debug Data5",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
-      ],
-      "sensors": [
-        "Input 6 Amperage",
-        "Output 3 Wattage",
-        "Output DC voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 24,
-      "register_start": 24,
-      "register_end": 24,
-      "name": "Input 6 Amperage",
-      "description": "g DSP067 Debug Data6",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
-      ],
-      "sensors": [
-        "Input 6 Amperage",
-        "Output 3 Wattage",
-        "Output DC voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 24,
-      "register_start": 24,
-      "register_end": 24,
-      "name": "Input 6 Amperage",
-      "description": "g DSP067 Debug Data7",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
-      ],
-      "sensors": [
-        "Input 6 Amperage",
-        "Output 3 Wattage",
-        "Output DC voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 24,
-      "register_start": 24,
-      "register_end": 24,
-      "name": "Input 6 Amperage",
-      "description": "g DSP067 Debug Data8",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
-      ],
-      "sensors": [
-        "Input 6 Amperage",
-        "Output 3 Wattage",
-        "Output DC voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Se cond group",
-      "register": 24,
-      "register_start": 24,
-      "register_end": 24,
-      "name": "Input 6 Amperage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_6_amperage",
-        "output_3_power",
-        "output_dc_voltage"
-      ],
-      "sensors": [
-        "Input 6 Amperage",
-        "Output 3 Wattage",
-        "Output DC voltage"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "Th e eighth group for PV9-PV 16 information"
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 87,
-      "register_start": 87,
-      "register_end": 87,
-      "name": "Input 8 energy today",
-      "description": "PV9 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_today"
-      ],
-      "sensors": [
-        "Input 8 energy today"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 87,
-      "register_start": 87,
-      "register_end": 87,
-      "name": "Input 8 energy today",
-      "description": "PV9 Input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_today"
-      ],
-      "sensors": [
-        "Input 8 energy today"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 87,
-      "register_start": 87,
-      "register_end": 87,
-      "name": "Input 8 energy today",
-      "description": "PV9 input power (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_today"
-      ],
-      "sensors": [
-        "Input 8 energy today"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 87,
-      "register_start": 87,
-      "register_end": 87,
-      "name": "Input 8 energy today",
-      "description": "PV9 input power (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_today"
-      ],
-      "sensors": [
-        "Input 8 energy today"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 87,
-      "register_start": 87,
-      "register_end": 87,
-      "name": "Input 8 energy today",
-      "description": "PV10 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_today"
-      ],
-      "sensors": [
-        "Input 8 energy today"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 88,
-      "register_start": 88,
-      "register_end": 88,
-      "name": "0 PV10Curr",
-      "description": "PV10 Input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 88,
-      "register_start": 88,
-      "register_end": 88,
-      "name": "1 Ppv10 H",
-      "description": "PV10 input power (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 88,
-      "register_start": 88,
-      "register_end": 88,
-      "name": "2 Ppv10 L",
-      "description": "PV10 input power (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 88,
-      "register_start": 88,
-      "register_end": 88,
-      "name": "3 Vpv11",
-      "description": "PV11 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 88,
-      "register_start": 88,
-      "register_end": 88,
-      "name": "4 PV11Curr",
-      "description": "PV11 Input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 88,
-      "register_start": 88,
-      "register_end": 88,
-      "name": "5 Ppv11 H",
-      "description": "PV11 input power (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 88,
-      "register_start": 88,
-      "register_end": 88,
-      "name": "6 Ppv11 L",
-      "description": "PV11 input power (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 88,
-      "register_start": 88,
-      "register_end": 88,
-      "name": "7 Vpv12",
-      "description": "PV12 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 88,
-      "register_start": 88,
-      "register_end": 88,
-      "name": "8 PV12Curr",
-      "description": "PV12 Input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 88,
-      "register_start": 88,
-      "register_end": 88,
-      "name": "9 Ppv12 H",
-      "description": "PV12 input power (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 89,
-      "register_start": 89,
-      "register_end": 89,
-      "name": "Input 8 total energy",
-      "description": "PV12 input power (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_total"
-      ],
-      "sensors": [
-        "Input 8 total energy"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 89,
-      "register_start": 89,
-      "register_end": 89,
-      "name": "Input 8 total energy",
-      "description": "PV13 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_total"
-      ],
-      "sensors": [
-        "Input 8 total energy"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 89,
-      "register_start": 89,
-      "register_end": 89,
-      "name": "Input 8 total energy",
-      "description": "PV13 Input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_total"
-      ],
-      "sensors": [
-        "Input 8 total energy"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 89,
-      "register_start": 89,
-      "register_end": 89,
-      "name": "Input 8 total energy",
-      "description": "PV13 input power (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_total"
-      ],
-      "sensors": [
-        "Input 8 total energy"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 89,
-      "register_start": 89,
-      "register_end": 89,
-      "name": "Input 8 total energy",
-      "description": "PV13 input power (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_total"
-      ],
-      "sensors": [
-        "Input 8 total energy"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 89,
-      "register_start": 89,
-      "register_end": 89,
-      "name": "Input 8 total energy",
-      "description": "PV14 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_total"
-      ],
-      "sensors": [
-        "Input 8 total energy"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 89,
-      "register_start": 89,
-      "register_end": 89,
-      "name": "Input 8 total energy",
-      "description": "PV14 Input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_total"
-      ],
-      "sensors": [
-        "Input 8 total energy"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 89,
-      "register_start": 89,
-      "register_end": 89,
-      "name": "Input 8 total energy",
-      "description": "PV14 input power (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_total"
-      ],
-      "sensors": [
-        "Input 8 total energy"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 89,
-      "register_start": 89,
-      "register_end": 89,
-      "name": "Input 8 total energy",
-      "description": "PV14 input power (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_total"
-      ],
-      "sensors": [
-        "Input 8 total energy"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 89,
-      "register_start": 89,
-      "register_end": 89,
-      "name": "Input 8 total energy",
-      "description": "PV15 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_energy_total"
-      ],
-      "sensors": [
-        "Input 8 total energy"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 90,
-      "register_start": 90,
-      "register_end": 90,
-      "name": "0 PV15Curr",
-      "description": "PV15 Input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 90,
-      "register_start": 90,
-      "register_end": 90,
-      "name": "1 Ppv15 H",
-      "description": "PV15 input power (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 90,
-      "register_start": 90,
-      "register_end": 90,
-      "name": "2 Ppv15 L",
-      "description": "PV15 input power (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 90,
-      "register_start": 90,
-      "register_end": 90,
-      "name": "3 Vpv16",
-      "description": "PV16 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 90,
-      "register_start": 90,
-      "register_end": 90,
-      "name": "4 PV16Curr",
-      "description": "PV16 Input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 90,
-      "register_start": 90,
-      "register_end": 90,
-      "name": "5 Ppv16 H",
-      "description": "PV16 input power (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 90,
-      "register_start": 90,
-      "register_end": 90,
-      "name": "6 Ppv16 L",
-      "description": "PV16 input power (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 90,
-      "register_start": 90,
-      "register_end": 90,
-      "name": "7 Epv9_today H",
-      "description": "PV9 energy today (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 90,
-      "register_start": 90,
-      "register_end": 90,
-      "name": "8 Epv9_today L",
-      "description": "PV9 energy today (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 90,
-      "register_start": 90,
-      "register_end": 90,
-      "name": "9 Epv9_total H",
-      "description": "PV9 energy total (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 91,
-      "register_start": 91,
-      "register_end": 91,
-      "name": "Total energy input",
-      "description": "PV9 energy total (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_energy_total"
-      ],
-      "sensors": [
-        "Total energy input"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 91,
-      "register_start": 91,
-      "register_end": 91,
-      "name": "Total energy input",
-      "description": "PV10 energy today (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_energy_total"
-      ],
-      "sensors": [
-        "Total energy input"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 91,
-      "register_start": 91,
-      "register_end": 91,
-      "name": "Total energy input",
-      "description": "PV10 energy today (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_energy_total"
-      ],
-      "sensors": [
-        "Total energy input"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 91,
-      "register_start": 91,
-      "register_end": 91,
-      "name": "Total energy input",
-      "description": "PV10 energy total (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_energy_total"
-      ],
-      "sensors": [
-        "Total energy input"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 91,
-      "register_start": 91,
-      "register_end": 91,
-      "name": "Total energy input",
-      "description": "PV10 energy total (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_energy_total"
-      ],
-      "sensors": [
-        "Total energy input"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 91,
-      "register_start": 91,
-      "register_end": 91,
-      "name": "Total energy input",
-      "description": "PV11 energy today (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_energy_total"
-      ],
-      "sensors": [
-        "Total energy input"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 91,
-      "register_start": 91,
-      "register_end": 91,
-      "name": "Total energy input",
-      "description": "PV11 energy today (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_energy_total"
-      ],
-      "sensors": [
-        "Total energy input"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 91,
-      "register_start": 91,
-      "register_end": 91,
-      "name": "Total energy input",
-      "description": "PV11 energy total (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_energy_total"
-      ],
-      "sensors": [
-        "Total energy input"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 91,
-      "register_start": 91,
-      "register_end": 91,
-      "name": "Total energy input",
-      "description": "PV11 energy total (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_energy_total"
-      ],
-      "sensors": [
-        "Total energy input"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 91,
-      "register_start": 91,
-      "register_end": 91,
-      "name": "Total energy input",
-      "description": "PV12 energy today (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_energy_total"
-      ],
-      "sensors": [
-        "Total energy input"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 92,
-      "register_start": 92,
-      "register_end": 92,
-      "name": "0 Epv12_today L",
-      "description": "PV12 energy today (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 92,
-      "register_start": 92,
-      "register_end": 92,
-      "name": "1 Epv12_total H",
-      "description": "PV12 energy total (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 92,
-      "register_start": 92,
-      "register_end": 92,
-      "name": "2 Epv12_total L",
-      "description": "PV12 energy total (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 92,
-      "register_start": 92,
-      "register_end": 92,
-      "name": "3 Epv13_today H",
-      "description": "PV13 energy today (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 92,
-      "register_start": 92,
-      "register_end": 92,
-      "name": "4 Epv13_today L",
-      "description": "PV13 energy today (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 92,
-      "register_start": 92,
-      "register_end": 92,
-      "name": "5 Epv13_total H",
-      "description": "PV13 energy total (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 92,
-      "register_start": 92,
-      "register_end": 92,
-      "name": "6 Epv13_total L",
-      "description": "PV13 energy total (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 92,
-      "register_start": 92,
-      "register_end": 92,
-      "name": "7 Epv14_today H",
-      "description": "PV14 energy today (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 92,
-      "register_start": 92,
-      "register_end": 92,
-      "name": "8 Epv14_today L",
-      "description": "PV14 energy today (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 92,
-      "register_start": 92,
-      "register_end": 92,
-      "name": "9 Epv14_total H",
-      "description": "PV14 energy total (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 93,
-      "register_start": 93,
-      "register_end": 93,
-      "name": "Temperature",
-      "description": "PV14 energy total (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 93,
-      "register_start": 93,
-      "register_end": 93,
-      "name": "Temperature",
-      "description": "PV15 energy today (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 93,
-      "register_start": 93,
-      "register_end": 93,
-      "name": "Temperature",
-      "description": "PV15 energy today (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 93,
-      "register_start": 93,
-      "register_end": 93,
-      "name": "Temperature",
-      "description": "PV15 energy total (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 93,
-      "register_start": 93,
-      "register_end": 93,
-      "name": "Temperature",
-      "description": "PV15 energy total (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 93,
-      "register_start": 93,
-      "register_end": 93,
-      "name": "Temperature",
-      "description": "PV16 energy today (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 93,
-      "register_start": 93,
-      "register_end": 93,
-      "name": "Temperature",
-      "description": "PV16 energy today (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 93,
-      "register_start": 93,
-      "register_end": 93,
-      "name": "Temperature",
-      "description": "PV16 energy total (High)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 93,
-      "register_start": 93,
-      "register_end": 93,
-      "name": "Temperature",
-      "description": "PV16 energy total (Low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 93,
-      "register_start": 93,
-      "register_end": 93,
-      "name": "Temperature",
-      "description": "PID PV9PE Volt/ Flyspan volta (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 94,
-      "register_start": 94,
-      "register_end": 94,
-      "name": "Intelligent Power Management temperature",
-      "description": "PID PV9PE Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 94,
-      "register_start": 94,
-      "register_end": 94,
-      "name": "Intelligent Power Management temperature",
-      "description": "+ PID PV10PE/ Flyspan voltage ( HV)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 94,
-      "register_start": 94,
-      "register_end": 94,
-      "name": "Intelligent Power Management temperature",
-      "description": "0+ PID PV10PE Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 94,
-      "register_start": 94,
-      "register_end": 94,
-      "name": "Intelligent Power Management temperature",
-      "description": "1+ PID PV11PE Volt/ Flyspan volt (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 94,
-      "register_start": 94,
-      "register_end": 94,
-      "name": "Intelligent Power Management temperature",
-      "description": "1+ PID PV11PE Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 94,
-      "register_start": 94,
-      "register_end": 94,
-      "name": "Intelligent Power Management temperature",
-      "description": "2+ PID PV12PE Volt/ Flyspan volt (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 94,
-      "register_start": 94,
-      "register_end": 94,
-      "name": "Intelligent Power Management temperature",
-      "description": "2+ PID PV12PE Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 94,
-      "register_start": 94,
-      "register_end": 94,
-      "name": "Intelligent Power Management temperature",
-      "description": "3+ PID PV13PE Volt/ Flyspan volt (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 94,
-      "register_start": 94,
-      "register_end": 94,
-      "name": "Intelligent Power Management temperature",
-      "description": "3+ PID PV13PE Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 94,
-      "register_start": 94,
-      "register_end": 94,
-      "name": "Intelligent Power Management temperature",
-      "description": "4+ PID PV14PE Volt/ Flyspan volt (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 95,
-      "register_start": 95,
-      "register_end": 95,
-      "name": "Boost temperature",
-      "description": "4+ PID PV14PE Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "boost_temperature"
-      ],
-      "sensors": [
-        "Boost temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 95,
-      "register_start": 95,
-      "register_end": 95,
-      "name": "Boost temperature",
-      "description": "5+ PID PV15PE Volt/ Flyspan volt (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "boost_temperature"
-      ],
-      "sensors": [
-        "Boost temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 95,
-      "register_start": 95,
-      "register_end": 95,
-      "name": "Boost temperature",
-      "description": "5+ PID PV15PE Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "boost_temperature"
-      ],
-      "sensors": [
-        "Boost temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 95,
-      "register_start": 95,
-      "register_end": 95,
-      "name": "Boost temperature",
-      "description": "6+ PID PV16PE Volt/ Flyspan volt (MAX HV)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "boost_temperature"
-      ],
-      "sensors": [
-        "Boost temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 95,
-      "register_start": 95,
-      "register_end": 95,
-      "name": "Boost temperature",
-      "description": "6+ PID PV16PE Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "boost_temperature"
-      ],
-      "sensors": [
-        "Boost temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 95,
-      "register_start": 95,
-      "register_end": 95,
-      "name": "Boost temperature",
-      "description": "PV String 17 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "boost_temperature"
-      ],
-      "sensors": [
-        "Boost temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 95,
-      "register_start": 95,
-      "register_end": 95,
-      "name": "Boost temperature",
-      "description": "PV String 17 Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "boost_temperature"
-      ],
-      "sensors": [
-        "Boost temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 95,
-      "register_start": 95,
-      "register_end": 95,
-      "name": "Boost temperature",
-      "description": "PV String 18 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "boost_temperature"
-      ],
-      "sensors": [
-        "Boost temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 95,
-      "register_start": 95,
-      "register_end": 95,
-      "name": "Boost temperature",
-      "description": "PV String 18 Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "boost_temperature"
-      ],
-      "sensors": [
-        "Boost temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 95,
-      "register_start": 95,
-      "register_end": 95,
-      "name": "Boost temperature",
-      "description": "PV String 19 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "boost_temperature"
-      ],
-      "sensors": [
-        "Boost temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 96,
-      "register_start": 96,
-      "register_end": 96,
-      "name": "0 Curr _String19",
-      "description": "PV String 19 Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 96,
-      "register_start": 96,
-      "register_end": 96,
-      "name": "1 V _String20",
-      "description": "PV String 20 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 96,
-      "register_start": 96,
-      "register_end": 96,
-      "name": "2 Curr _String20",
-      "description": "PV String 20 Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 96,
-      "register_start": 96,
-      "register_end": 96,
-      "name": "3 V _String21",
-      "description": "PV String 21 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 96,
-      "register_start": 96,
-      "register_end": 96,
-      "name": "4 Curr _String21",
-      "description": "PV String 21 Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 96,
-      "register_start": 96,
-      "register_end": 96,
-      "name": "5 V _String22",
-      "description": "PV String22 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 96,
-      "register_start": 96,
-      "register_end": 96,
-      "name": "6 Curr _String22",
-      "description": "PV String 22 Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 96,
-      "register_start": 96,
-      "register_end": 96,
-      "name": "7 V _String23",
-      "description": "PV String 23 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 96,
-      "register_start": 96,
-      "register_end": 96,
-      "name": "8 Curr _String23",
-      "description": "PV String 23 Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 96,
-      "register_start": 96,
-      "register_end": 96,
-      "name": "9 V _String24",
-      "description": "PV String 24 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 97,
-      "register_start": 97,
-      "register_end": 97,
-      "name": "0 Curr _String24",
-      "description": "PV String 24 Current",
-      "access": null,
-      "range": null,
-      "unit": "0.1A",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 97,
-      "register_start": 97,
-      "register_end": 97,
-      "name": "1 V _String25",
-      "description": "PV String 25 voltage",
-      "access": null,
-      "range": null,
-      "unit": "0.1V",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 97,
-      "register_start": 97,
-      "register_end": 97,
-      "name": "2 Curr _String25",
-      "description": "PV String 25 Current",
-      "access": null,
-      "range": null,
-      "unit": "0.1A",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 97,
-      "register_start": 97,
-      "register_end": 97,
-      "name": "3 V _String26",
-      "description": "PV String 26 voltage",
-      "access": null,
-      "range": null,
-      "unit": "0.1V",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 97,
-      "register_start": 97,
-      "register_end": 97,
-      "name": "4 Curr _String26",
-      "description": "PV String 26 Current",
-      "access": null,
-      "range": null,
-      "unit": "0.1A",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 97,
-      "register_start": 97,
-      "register_end": 97,
-      "name": "5 V _String27",
-      "description": "PV String 27 voltage",
-      "access": null,
-      "range": null,
-      "unit": "0.1V",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 97,
-      "register_start": 97,
-      "register_end": 97,
-      "name": "6 Curr _String27",
-      "description": "PV String 27 Current",
-      "access": null,
-      "range": null,
-      "unit": "0.1A",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 97,
-      "register_start": 97,
-      "register_end": 97,
-      "name": "7 V _String28",
-      "description": "PV String 28 voltage",
-      "access": null,
-      "range": null,
-      "unit": "0.1V",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 97,
-      "register_start": 97,
-      "register_end": 97,
-      "name": "8 Curr _String28",
-      "description": "PV String 28 Current",
-      "access": null,
-      "range": null,
-      "unit": "0.1A",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 97,
-      "register_start": 97,
-      "register_end": 97,
-      "name": "9 V _String29",
-      "description": "PV String 29 voltage",
-      "access": null,
-      "range": null,
-      "unit": "0.1V",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 98,
-      "register_start": 98,
-      "register_end": 98,
-      "name": "P-bus voltage",
-      "description": "PV String 29 Current",
-      "access": null,
-      "range": null,
-      "unit": "0.1A",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "P-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 98,
-      "register_start": 98,
-      "register_end": 98,
-      "name": "P-bus voltage",
-      "description": "PV String 30 voltage",
-      "access": null,
-      "range": null,
-      "unit": "0.1V",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "P-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 98,
-      "register_start": 98,
-      "register_end": 98,
-      "name": "P-bus voltage",
-      "description": "PV String 30 Current",
-      "access": null,
-      "range": null,
-      "unit": "0.1A",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "P-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 98,
-      "register_start": 98,
-      "register_end": 98,
-      "name": "P-bus voltage",
-      "description": "PV String 31 voltage",
-      "access": null,
-      "range": null,
-      "unit": "0.1V",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "P-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 98,
-      "register_start": 98,
-      "register_end": 98,
-      "name": "P-bus voltage",
-      "description": "PV String 31 Current",
-      "access": null,
-      "range": null,
-      "unit": "0.1A",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "P-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 98,
-      "register_start": 98,
-      "register_end": 98,
-      "name": "P-bus voltage",
-      "description": "PV String 32 voltage",
-      "access": null,
-      "range": null,
-      "unit": "0.1V",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "P-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 98,
-      "register_start": 98,
-      "register_end": 98,
-      "name": "P-bus voltage",
-      "description": "PV String 32 Current",
-      "access": null,
-      "range": null,
-      "unit": "0.1A",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "P-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 98,
-      "register_start": 98,
-      "register_end": 98,
-      "name": "P-bus voltage",
-      "description": "Bit0~15: String 17~32 unmatch",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "P-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 98,
-      "register_start": 98,
-      "register_end": 98,
-      "name": "P-bus voltage",
-      "description": "Bit0~15:String 17~32 unblance",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "P-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 98,
-      "register_start": 98,
-      "register_end": 98,
-      "name": "P-bus voltage",
-      "description": "Bit0~15: String 17~32 disconn",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "P-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 99,
-      "register_start": 99,
-      "register_end": 99,
-      "name": "N-bus voltage",
-      "description": "PV Warning Value (PV9-PV16) Contains PV9~16 abnormal, 和 Boost9~16 Drive anomalies",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "n_bus_voltage"
-      ],
-      "sensors": [
-        "N-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 99,
-      "register_start": 99,
-      "register_end": 99,
-      "name": "N-bus voltage",
-      "description": "string1~string16 abnormal",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "n_bus_voltage"
-      ],
-      "sensors": [
-        "N-bus voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Th e eighth group for PV9-PV 16 information",
-      "register": 99,
-      "register_start": 99,
-      "register_end": 99,
-      "name": "N-bus voltage",
-      "description": "string17~string32 abnormal",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "n_bus_voltage"
-      ],
-      "sensors": [
-        "N-bus voltage"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "……"
-    },
-    {
-      "type": "entry",
-      "section": "……",
-      "register": 99,
-      "register_start": 99,
-      "register_end": 99,
-      "name": "N-bus voltage",
-      "description": "M3 to DSP system command",
-      "access": null,
-      "range": null,
-      "unit": "system command",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "n_bus_voltage"
-      ],
-      "sensors": [
-        "N-bus voltage"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "Ni nth group for Storage pow er"
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "00. uwSysWorkMode",
-      "description": "System work mode",
-      "access": null,
-      "range": null,
-      "unit": "Theworkingmode displayed by the monitoring to the customer is: 0x00: waiting module 0x01: Self-test mode, 0x03:fault module 0x04:flash odule x05|0x06|0x07|0 08:normal odule",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "01. Systemfault word0",
-      "description": "System fault word0",
-      "access": null,
-      "range": null,
-      "unit": "lease refer to hefault escription of ybrid",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "02. Systemfault word1",
-      "description": "System fault word1",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "03. Systemfault word2",
-      "description": "System fault word2",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "04. Systemfault word3",
-      "description": "System fault word3",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "05. Systemfault word4",
-      "description": "System fault word4",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "06. Systemfault word5",
-      "description": "System fault word5",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "07. Systemfault word6",
-      "description": "System fault word6",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "08. Systemfault word7",
-      "description": "System fault word7",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "09. Pdischarge1 H",
-      "description": "Discharge power(high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "10. Pdischarge1 L",
-      "description": "Discharge power (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "11. Pcharge1 H",
-      "description": "Charge power(high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "12. Pcharge1 L",
-      "description": "Charge power (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "13. Vbat",
-      "description": "Battery voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "14. SOC",
-      "description": "State of charge Capacity",
-      "access": null,
-      "range": null,
-      "unit": "ith/leadacid",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "15. Pactouser R",
-      "description": "H AC power to user H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "16. Pactouser R",
-      "description": "L AC power to user L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "17. Pactouser S",
-      "description": "H Pactouser S H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "18. Pactouser S",
-      "description": "L Pactouser S L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "19. Pactouser T",
-      "description": "H Pactouser T H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "20. Pactouser T",
-      "description": "L Pactouser T H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "21. PactouserTotal H",
-      "description": "AC power to user total H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "22. PactouserTotal L",
-      "description": "AC power to user total L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "23. Pac to grid R H",
-      "description": "AC power to grid H",
-      "access": null,
-      "range": null,
-      "unit": "c output",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "24. Pac to grid R L",
-      "description": "AC power to grid L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "25. Pactogrid S H",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "26. Pactogrid S L",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "27. Pactogrid T H",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "28. Pactogrid T L",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "29. Pactogrid total H",
-      "description": "AC power to grid total H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "30. Pactogrid total L",
-      "description": "AC power to grid total L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "31. PLocalLoad R",
-      "description": "H INV power to local load H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "32. PLocalLoad R",
-      "description": "L INV power to local load L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "33. PLocalLoad S",
-      "description": "H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "34. PLocalLoad S",
-      "description": "L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "35. PLocalLoadT H",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "36. PLocalLoadT L",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "37. PLocalLoad total",
-      "description": "H INV power to local load tot",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "38. PLocalLoad total",
-      "description": "L INV power to local load tot L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "39. IPM 2 Temperature",
-      "description": "REC Temperature",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "40. Battery 2 Temperature",
-      "description": "Battery Temperature",
-      "access": null,
-      "range": null,
-      "unit": "ithium p",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "41. SP DSP Status",
-      "description": "SP state",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "42. SP Bus Volt",
-      "description": "SP BUS2 Volt",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group for Storage pow er",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "43",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "section",
-      "title": "Po wer generation data"
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "44. Etouser_today H",
-      "description": "Energy to user today high",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "45. Etouser_today L",
-      "description": "Energy to user today low",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "46. Etouser_total H",
-      "description": "Energy to user total high",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "47. Etouser_ total L",
-      "description": "Energy to user total high",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "48. Etogrid_today H",
-      "description": "Energy to grid today high",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "49. Etogrid _today L",
-      "description": "Energy to grid today low",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "50. Etogrid _total H",
-      "description": "Energy to grid total high",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "51. Etogrid _ total L",
-      "description": "Energy to grid total high",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "52. Edischarge1_toda yH",
-      "description": "Discharge energy1 today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "53. Edischarge1_toda yL",
-      "description": "Discharge energy1 today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "54. Edischarge1_total H",
-      "description": "Total discharge energy1 (high)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "55. Edischarge1_total L",
-      "description": "Total discharge energy1 (low)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "56. Echarge1_today H",
-      "description": "Charge1 energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "57. Echarge1_today L",
-      "description": "Charge1 energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "58. Echarge1_total H",
-      "description": "Charge1 energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "59. Echarge1_total L",
-      "description": "Charge1 energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "60. ELocalLoad_Today H",
-      "description": "Local load energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "61. ELocalLoad_Today L",
-      "description": "Local load energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "62. ELocalLoad_Total H",
-      "description": "Local load energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "63. ELocalLoad_Total L",
-      "description": "Local load energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "64. dwExportLimitAp parentPower",
-      "description": "ExportLimitApparentPower H",
-      "access": null,
-      "range": null,
-      "unit": "rentPower",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "65. dwExportLimitAp parentPower",
-      "description": "ExportLimitApparentPower L",
-      "access": null,
-      "range": null,
-      "unit": "rentPower",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Po wer generation data",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "66. /",
-      "description": "/",
-      "access": null,
-      "range": null,
-      "unit": "rved",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "section",
-      "title": "Up s information (offline)"
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "67. EPS Fac",
-      "description": "UPSfrequency",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "68. EPS Vac1",
-      "description": "UPS phase R output voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "69. EPS Iac1",
-      "description": "UPS phase R output current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "70. EPS Pac1 H",
-      "description": "UPS phase R output power (H)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "71. EPS Pac1 L",
-      "description": "UPS phase R output power (L)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "72. EPS Vac2",
-      "description": "UPS phase S output voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "73. EPS Iac2",
-      "description": "UPS phase S output current",
-      "access": null,
-      "range": null,
-      "unit": "se",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "74. EPS Pac2 H",
-      "description": "UPS phase S output power (H)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "75. EPS Pac2 L",
-      "description": "UPS phase S output power (L)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "76. EPS Vac3",
-      "description": "UPS phase T output voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "77. EPS Iac3",
-      "description": "UPS phase T output current",
-      "access": null,
-      "range": null,
-      "unit": "se",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "78. EPS Pac3 H",
-      "description": "UPS phase T output power (H)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "79. EPS Pac3 L",
-      "description": "UPS phase T output power (L)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "80. Loadpercent",
-      "description": "Load percent of UPS ouput",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "Up s information (offline)",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "81. PF",
-      "description": "Power factor",
-      "access": null,
-      "range": null,
-      "unit": "ary Value+1",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "section",
-      "title": "BM S Infomation"
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "82. BMS_StatusOld",
-      "description": "StatusOld from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "83. BMS_Status",
-      "description": "Status from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "84. BMS_ErrorOld",
-      "description": "Error info Old from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "85. BMS_Error",
-      "description": "Errorinfomation from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "86. BMS_SOC BMS_BatteryVol",
-      "description": "SOC from BMS Battery voltage from BMS",
-      "access": null,
-      "range": null,
-      "unit": "H6K H6K",
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "87. t BMS_BatteryCur",
-      "description": "Battery current from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "88. r BMS_BatteryTe",
-      "description": "Battery temperature from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "89. mp BMS_MaxCurr",
-      "description": "Max. charge/discharge current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "90.",
-      "description": "from BMS (pylon)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "91. BMS_GaugeRM",
-      "description": "Gauge RM from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "92. BMS_GaugeFCC",
-      "description": "Gauge FCC from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "93. BMS_FW",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "94. BMS_DeltaVolt",
-      "description": "Delta V from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "95. BMS_CycleCnt",
-      "description": "Cycle Count from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "96. BMS_SOH BMS_ConstantV",
-      "description": "SOH from BMS CV voltage from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "97. olt BMS_WarnInfoO",
-      "description": "Warning info old from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "98. ld",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 10,
-      "register_start": 10,
-      "register_end": 10,
-      "name": "99. BMS_WarnInfo BMS_GaugeICCu",
-      "description": "Warning info from BMS Gauge IC current from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "MCU Software version from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Gauge Version from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Gauge FR Version L16 from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Gauge FR Version H16 from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "BMSInformation from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Pack Information from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Using Cap from BMS",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Maximum single battery voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Lowest single battery voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Battery parallel number",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Number of batteries MaxVoltCellNo",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "MinVoltCellNo",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "MaxTemprCell_10T",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "MinTemprCell_10T",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "MaxVoltTemprCellNo",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "MinVoltTemprCellNo",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Faulty Battery Address",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Parallel maximum SOC",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Parallel minimum SOC Battery Protection 2",
-      "access": null,
-      "range": null,
-      "unit": "CAN ID: 0x323",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Battery Protection3",
-      "access": null,
-      "range": null,
-      "unit": "Byte4~5 CAN ID: 0x323",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Battery Warn2",
-      "access": null,
-      "range": null,
-      "unit": "Byte6 CAN ID: 0x323",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "Byte7",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "BM S Infomation",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "AC Charge Energy today",
-      "access": null,
-      "range": null,
-      "unit": "Energy today",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "Ni nth group reserved for st orage power"
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "AC Charge Energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "Energy total",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "AC Charge Power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "AC Charge Power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "uwGridPower_70_AdjEE_SP",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "tra inverte AC Power to grid gh",
-      "access": null,
-      "range": null,
-      "unit": "SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "trainverte AC Power to grid Low",
-      "access": null,
-      "range": null,
-      "unit": "SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Extra inverter PowerTOUser_Extr today (high)",
-      "access": null,
-      "range": null,
-      "unit": "SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Extra inverter PowerTOUser_Extr today (low)",
-      "access": null,
-      "range": null,
-      "unit": "SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Extra inverter PowerTOUser_Extr total(high)",
-      "access": null,
-      "range": null,
-      "unit": "SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Extra inverter PowerTOUser_Extr total(low)",
-      "access": null,
-      "range": null,
-      "unit": "SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "System electric energy today H",
-      "access": null,
-      "range": null,
-      "unit": "SPA used System electric energy today H",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "stem electric energy today L",
-      "access": null,
-      "range": null,
-      "unit": "d electric today L",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "System electric energy total H",
-      "access": null,
-      "range": null,
-      "unit": "d electric total H",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "System electric energy total L",
-      "access": null,
-      "range": null,
-      "unit": "d electric total L",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "self electric energy today H",
-      "access": null,
-      "range": null,
-      "unit": "electric today H",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "self electric energy today L",
-      "access": null,
-      "range": null,
-      "unit": "electric today L",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "self electric energy total H",
-      "access": null,
-      "range": null,
-      "unit": "electric total H",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "self electric energy total L",
-      "access": null,
-      "range": null,
-      "unit": "electric total L",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "System power H",
-      "access": null,
-      "range": null,
-      "unit": "power H",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "System power L",
-      "access": null,
-      "range": null,
-      "unit": "power L",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "self power H",
-      "access": null,
-      "range": null,
-      "unit": "wer H",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "self power L",
-      "access": null,
-      "range": null,
-      "unit": "wer L",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "PV electric energy today H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "PV electric energy today L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Discharge power pack number",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Cumulative discharge power high 16-bit byte",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Cumulative discharge power low 16-bit byte",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "charge power pack serial number",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Cumulative charge power high R 16-bit byte",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Cumulative charge power low R 16-bit byte",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "FirstBattFaultSn",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Second BattFaultSn",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Third BattFaultSn",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Fourth BattFaultSn",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Battery history fault code 1",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Battery history fault code 2",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Battery history fault code 3",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Battery history fault code 4",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Battery history fault code 5",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Battery history fault code 6",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Battery history fault code 7",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Battery history fault code 8",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Number of battery codes PACK number + BIC forward and reverse codes",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Ni nth group reserved for st orage power",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "…… / / / / reversed"
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 11,
-      "register_start": 11,
-      "register_end": 11,
-      "name": "Input 3 voltage",
-      "description": "Intelligent reading is used to identify software compatibility features",
-      "access": null,
-      "range": null,
-      "unit": "rgy; rgy",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_3_voltage",
-        "output_power"
-      ],
-      "sensors": [
-        "Input 3 voltage",
-        "Output power"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "Maximum cell voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "Minimum cell voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "Number of Battery modules",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "Total number of cells",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "MaxVoltCellNo",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "MinVoltCellNo",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "MaxTemprCell_10T",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "MinTemprCell_10T",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "MaxTemprCellNo",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "MinTemprCellNo",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "Fault Pack ID",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "Parallel maximum SOC",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "Parallel minimum SOC",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "BatProtect1Add",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "BatProtect2Add",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "BatWarn1Add",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "BMS_HighestSoftVersion",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "BMS_HardwareVersion",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 1,
-      "register_start": 1,
-      "register_end": 1,
-      "name": "Input 1 voltage",
-      "description": "BMS_RequestType",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_voltage",
-        "input_power"
-      ],
-      "sensors": [
-        "Input 1 voltage",
-        "Internal wattage",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "…… / / / / reversed"
-    },
-    {
-      "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 12,
-      "register_start": 12,
-      "register_end": 12,
-      "name": "Input 3 Amperage",
-      "description": "Success sign of key detection before aging",
-      "access": null,
-      "range": null,
-      "unit": "1:Finished test 0: test not completed",
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3012,
+      "register_start": 3012,
+      "register_end": 3012,
+      "name": "PV3 DC current",
+      "description": "Instantaneous PV3 string current flowing into the inverter.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
         "input_3_amperage"
-      ],
-      "sensors": [
-        "Input 3 Amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "…… / / / / reversed",
-      "register": 12,
-      "register_start": 12,
-      "register_end": 12,
-      "name": "Input 3 Amperage",
-      "description": "/",
-      "access": null,
-      "range": null,
-      "unit": "reversed",
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3013,
+      "register_start": 3013,
+      "register_end": 3014,
+      "name": "PV3 DC power",
+      "description": "Real-time DC power from PV3 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "input_3_amperage"
-      ],
-      "sensors": [
-        "Input 3 Amperage"
+        "input_3_power"
       ]
     },
     {
-      "type": "section",
-      "title": "th irteen group for Storage power’s SPA"
-    },
-    {
-      "type": "entry",
-      "section": "th irteen group for Storage power’s SPA",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Inverter run state",
-      "access": null,
-      "range": null,
-      "unit": "SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "…… reversed"
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Output power (high)",
-      "access": null,
-      "range": null,
-      "unit": "1W SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Output power (low)",
-      "access": null,
-      "range": null,
-      "unit": "1W SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Grid frequency",
-      "access": null,
-      "range": null,
-      "unit": "01Hz SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Three/single phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": "1V SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Three/single phase grid output",
-      "access": null,
-      "range": null,
-      "unit": "1A SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Three/single phase grid output VA (high)",
-      "access": null,
-      "range": null,
-      "unit": "1VA SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Three/single phase grid output VA(low)",
-      "access": null,
-      "range": null,
-      "unit": "1VA SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "…… reversed"
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Today generate energy (high)",
-      "access": null,
-      "range": null,
-      "unit": "1kWH SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Today generate energy (low)",
-      "access": null,
-      "range": null,
-      "unit": "1kWH SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Total generate energy (high)",
-      "access": null,
-      "range": null,
-      "unit": "WH SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Total generate energy (low)",
-      "access": null,
-      "range": null,
-      "unit": "WH SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Work time total (high)",
-      "access": null,
-      "range": null,
-      "unit": "SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Work time total (low)",
-      "access": null,
-      "range": null,
-      "unit": "SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "…… reversed"
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Inverter temperature",
-      "access": null,
-      "range": null,
-      "unit": "SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "The inside IPM in inverter Temp",
-      "access": null,
-      "range": null,
-      "unit": "SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "Boost temperature",
-      "access": null,
-      "range": null,
-      "unit": "SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "reserved",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "BatVolt_DSP",
-      "access": null,
-      "range": null,
-      "unit": "BatVolt(DSP)",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "P Bus inside Voltage",
-      "access": null,
-      "range": null,
-      "unit": "SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 20,
-      "register_start": 20,
-      "register_end": 20,
-      "name": "Grid voltage",
-      "description": "N Bus inside Voltage",
-      "access": null,
-      "range": null,
-      "unit": "SPA",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_voltage",
-        "input_5_amperage",
-        "output_2_power"
-      ],
-      "sensors": [
-        "Grid voltage",
-        "Input 5 Amperage",
-        "Output 2 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "/",
-      "access": null,
-      "range": null,
-      "unit": "Remote setup enable",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "/",
-      "access": null,
-      "range": null,
-      "unit": "Remotely set power",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "Extra inverte AC Power to grid",
-      "access": null,
-      "range": null,
-      "unit": "SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "Extrainverte AC Power to grid L",
-      "access": null,
-      "range": null,
-      "unit": "SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "Extra inverter PowerTOUser_Extr today (high)",
-      "access": null,
-      "range": null,
-      "unit": "Wh SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "Extra inverter PowerTOUser_Extr today (low)",
-      "access": null,
-      "range": null,
-      "unit": "Wh SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "Extra inverter PowerTOUser_Extratotal(high)",
-      "access": null,
-      "range": null,
-      "unit": "Wh SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "Extra inverter PowerTOUser_Extr total(low)",
-      "access": null,
-      "range": null,
-      "unit": "Wh SPA used",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "System electric energy today H",
-      "access": null,
-      "range": null,
-      "unit": "Wh SPA used System electric energy today H",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "stem electric energy today L",
-      "access": null,
-      "range": null,
-      "unit": "Wh SPA used System electric energy today L",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "System electric energy total H",
-      "access": null,
-      "range": null,
-      "unit": "Wh SPA used System c total",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "System electric energy total L",
-      "access": null,
-      "range": null,
-      "unit": "d c total",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "ACCharge energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "ACCharge energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "ACCharge energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "ACCharge energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "Grid power to local load",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "Grid power to local load",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "0:Load First 1:Battery First 2:Grid First",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "0:Lead-acid 1:Lithium battery",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "…… reversed",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": "Aging mode",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "… reserved reserve d"
-    },
-    {
-      "type": "entry",
-      "section": "… reserved reserve d",
-      "register": 21,
-      "register_start": 21,
-      "register_end": 21,
-      "name": "AC frequency",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "d",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "grid_frequency",
-        "input_5_power"
-      ],
-      "sensors": [
-        "AC frequency",
-        "Grid frequency",
-        "Input 5 Wattage"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "Us e for TL-X and TL-XH"
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "2: Reserved 3:SysFault module 4: Flash module 5:PVBATOnline module: 6:BatOnline module 7:PVOfflineMode 8:BatOfflineMode The lower 8 bits indicate the m status (web page display) 0: StandbyStatus; 1: NormalStatus; 3: FaultStatus 4:FlashStatus;",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV total power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV1 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV1 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV1 power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV2 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV2 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV2 power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV3 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV3 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV3 power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV4 voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV4 input current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV4 power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "System output power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "reactive power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Output power",
-      "access": null,
-      "range": null,
-      "unit": "ut",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Grid frequency",
-      "access": null,
-      "range": null,
-      "unit": "r",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three/single phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": "uency e/single",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "e grid age",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three/single phase grid output",
-      "access": null,
-      "range": null,
-      "unit": "e/single rid",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three/single phase grid output VA",
-      "access": null,
-      "range": null,
-      "unit": "ingle rid",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": "watt hase",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three phase grid output current",
-      "access": null,
-      "range": null,
-      "unit": "ltage hase",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "tput",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three phase grid output power",
-      "access": null,
-      "range": null,
-      "unit": "hase tput",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": "hase",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three phase grid output current",
-      "access": null,
-      "range": null,
-      "unit": "ltage hase",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "tput",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three phase grid output power",
-      "access": null,
-      "range": null,
-      "unit": "hase tput",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Three phase grid voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total forward power",
-      "access": null,
-      "range": null,
-      "unit": "orward",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total reverse power",
-      "access": null,
-      "range": null,
-      "unit": "everse",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total load power",
-      "access": null,
-      "range": null,
-      "unit": "load",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Work time total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Today generate energy",
-      "access": null,
-      "range": null,
-      "unit": "e",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total generate energy",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "e",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV1 energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV1 energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV2 energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV2 energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV3 energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV3 energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Today energy to user",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total energy to user",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Today energy to grid",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total energy to grid",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Today energy of user load",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total energy of user load",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV4 energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV4 energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "DeratingMode",
-      "access": null,
-      "range": null,
-      "unit": "h",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "k T lA i",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PV ISO value",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "R DCI Curr",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "S DCI Curr",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "T DCI Curr",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "GFCI Curr",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "total bus voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Inverter temperature",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "The inside IPM in inverter temp",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Boost temperature",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Reserved",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Commmunication broad temperatur",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "P Bus inside Voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "N Bus inside Voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Inverter output PF now",
-      "access": null,
-      "range": null,
-      "unit": "000",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Real Output power Percent",
-      "access": null,
-      "range": null,
-      "unit": "0",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Output Maxpower Limited",
-      "access": null,
-      "range": null,
-      "unit": "ut ower",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Inverter standby flag",
-      "access": null,
-      "range": null,
-      "unit": "ted:turn off r;:PV Low;:AC",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "/Freq of scope; ~bit7: rved",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Inverter fault maincode",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Inverter Warning maincode",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Inverter fault subcode",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Inverter Warning subcode",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "PresentFFTValue [CHANNEL_A]",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "AFCI Status",
-      "access": null,
-      "range": null,
-      "unit": "waiting e lf-check Detection",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "AFCI Strength[CHANNEL_A]",
-      "access": null,
-      "range": null,
-      "unit": "arcing e ult state update e",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "AFCI SelfCheck[CHANNEL_A]",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "inv start delay time",
-      "access": null,
-      "range": null,
-      "unit": "lay",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BDC connect state",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Current status of DryContact",
-      "access": null,
-      "range": null,
-      "unit": "of",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "self-use power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "System energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Today discharge energy",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total discharge energy",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Charge energy today",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Charge energy total",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Today energy of AC charge",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total energy of AC charge",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total energy of system outpu",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Today energy of Self output",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total energy of Self output",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Word Mode",
-      "access": null,
-      "range": null,
-      "unit": "adFirst",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "eryFirs idFirst",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "UPS frequency",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "UPS phase R output voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "UPS phase R output current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "UPS phase R output power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "UPS phase S output voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "UPS phase S output current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "UPS phase S output power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "UPS phase T output voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "UPS phase T output current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "UPS phase T output power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "UPS output power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Load percent of UPS ouput",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Power factor",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "DC voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Whether to parse BDC data separ",
-      "access": null,
-      "range": null,
-      "unit": "on't need",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BDCDeratingMode: 0: Normal, unrestricted 1:Standby or fault",
-      "access": null,
-      "range": null,
-      "unit": "ed",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "2:Maximum battery current limit (discharge) 3:Battery discharge Enable (Dis 4:High bus discharge derating (discharge) 5:High temperature discharge derating (discharge) 6:System warning No discharge (discharge) 7-15 Reserved (Discharge) 16:Maximum charging current of battery (charging) 17:High Temperature (LLC and Buckboost) (Charging) 18:Final soft charge 19:SOC setting limits (charging 20:Battery low temperature (cha 21:High bus voltage (charging) 22:Battery SOC (charging) 23: Need to charge (charge) 24: System warning not charging (charging) 25-29:Reserve (charge) System work State and mode The upper 8 bits indicate the mode; 0:No charge and discharge; 1:charge; 2:Discharge;",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "The lower 8 bits represent the 0: StandbyStatus; 1: NormalStatus; 2: FaultStatus 3:FlashStatus;",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Storge device fault code",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Storge device warning code",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Battery voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Battery current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "State of charge Capacity",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Total BUS voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "On the BUS voltage",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BUCK-BOOST Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "LLC Current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Temperture A",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Temperture B",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Discharge power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Charge power",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Discharge total energy of storg",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Charge total energy of storge d",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Reserved BDC mark (charge and dischar fault alarm code) Bit0: ChargeEn; BDC allows char Bit1: DischargeEn; BDC allows discharge",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Bit2~7: Resvd; reserved Bit8~11: WarnSubCode; BDC sub-warning code Bit12~15: FaultSubCode; BDC sub-error code",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Lower BUS voltage BmsMaxVoltCellNo",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BmsMinVoltCellNo",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BmsBatteryAvgTemp",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BmsMaxCellTemp",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BmsBatteryAvgTemp",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BmsMaxCellTemp",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BmsBatteryAvgTemp",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BmsMaxSOC",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BmsMinSOC ParallelBatteryNum",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BmsDerateReason",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BmsGaugeFCC(Ah)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BmsGaugeRM(Ah)",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMS Protect1",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMSWarn1",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMS Fault1",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMS Fault2",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Battery ISO detection status",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "battery work request",
-      "access": null,
-      "range": null,
-      "unit": "n",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "battery working status",
-      "access": null,
-      "range": null,
-      "unit": "mancy ge harge",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": "dby start t te",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMS Protect2",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMS Warn2",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
       "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMS SOC BMS BatteryVolt",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3015,
+      "register_start": 3015,
+      "register_end": 3015,
+      "name": "PV4 DC voltage",
+      "description": "Instantaneous PV4 string voltage measured at the inverter input.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
+        "input_4_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMS BatteryCurr",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3016,
+      "register_start": 3016,
+      "register_end": 3016,
+      "name": "PV4 DC current",
+      "description": "Instantaneous PV4 string current flowing into the inverter.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
+        "input_4_amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "battery cell maximum temperatur",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3017,
+      "register_start": 3017,
+      "register_end": 3018,
+      "name": "PV4 DC power",
+      "description": "Real-time DC power from PV4 computed from voltage and current readings.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
+        "input_4_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3021,
+      "register_start": 3021,
+      "register_end": 3022,
+      "name": "Output reactive power",
+      "description": "Instantaneous reactive power on the AC output (positive = inductive, negative = capacitive).",
+      "access": "R",
+      "unit": "var",
+      "data_type": "s32_reactive_power_decivar",
       "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
+        "output_reactive_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Maximum charging current Maximum discharge current",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3023,
+      "register_start": 3023,
+      "register_end": 3024,
+      "name": "AC output power",
+      "description": "Active AC output power delivered by the inverter (0.1 W resolution).",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
+        "output_power"
       ]
     },
     {
       "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3025,
+      "register_start": 3025,
+      "register_end": 3025,
+      "name": "Grid frequency",
+      "description": "Measured grid frequency with 0.01 Hz resolution.",
+      "access": "R",
+      "unit": "Hz",
+      "data_type": "u16_frequency_centihz",
       "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
+        "grid_frequency"
       ]
     },
     {
       "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMSCycleCnt",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3026,
+      "register_start": 3026,
+      "register_end": 3026,
+      "name": "AC phase L1 voltage",
+      "description": "AC output voltage for phase L1.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
+        "output_1_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMS SOH Battery charging voltage limit",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3027,
+      "register_start": 3027,
+      "register_end": 3027,
+      "name": "AC phase L1 current",
+      "description": "AC output current for phase L1.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
+        "output_1_amperage"
       ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "Battery discharge voltage limit",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMS Warn 3",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": "BMS Protect3",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 3,
-      "register_start": 3,
-      "register_end": 3,
-      "name": "Input 1 Wattage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_1_power",
-        "input_1_voltage"
-      ],
-      "sensors": [
-        "Input 1 Wattage",
-        "Input 1 voltage",
-        "PV1 charge power",
-        "PV1 voltage"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "BMS Battery SingleVoltMax",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "BMS Battery SingleVoltMin",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Battery LoadVolt",
-      "access": null,
-      "range": null,
-      "unit": "0,650.00]",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data1",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data2",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data3",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data4",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data5",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data6",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data7",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data8",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data9",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data10",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data10",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data12",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data13",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data14",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data15",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Debug data16",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 1 output power H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 1 output power L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 2 output power H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 2 output power L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 1 energy Today H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 1 energy Today L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 2 energy Today H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 2 energy Today L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 1 energy Total H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 1 energy Total L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 2 energy Total H",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "PV inverter 2 energy Total L",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "battery pack number",
-      "access": null,
-      "range": null,
-      "unit": "C reports e updated ery 15 nutes",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Battery pack serial numberSN[0]",
-      "access": null,
-      "range": null,
-      "unit": "C reports e updated",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Battery pack serial numberSN[2]",
-      "access": null,
-      "range": null,
-      "unit": "ery 15",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Battery pack serial numberSN[4]",
-      "access": null,
-      "range": null,
-      "unit": "nutes",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Battery pack serial numberSN[6]",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Battery pack serial numberSN[8]",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Battery pack serial numberSN[10]SN[11]",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Battery pack serial numberSN[12]SN[13]",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Battery pack serial numberSN[14]SN[15]",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Reserve",
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": null,
-      "access": null,
-      "range": null,
-      "unit": null,
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "entry",
-      "section": "Us e for TL-X and TL-XH",
-      "register": 32,
-      "register_start": 32,
-      "register_end": 32,
-      "name": "Input 8 Amperage",
-      "description": "Clear day data flag",
-      "access": null,
-      "range": null,
-      "unit": "ta of the rrent day at the rver determines whether to clear. 0:not cleared. 1: Clear.",
-      "initial": null,
-      "note": null,
-      "attributes": [
-        "input_8_amperage",
-        "inverter_temperature"
-      ],
-      "sensors": [
-        "Input 8 Amperage",
-        "Temperature"
-      ]
-    },
-    {
-      "type": "section",
-      "title": "BD C and BMS information (su pport up to 10 PARALLEL BDCS)"
     },
     {
       "type": "entry",
-      "section": "BD C and BMS information (su pport up to 10 PARALLEL BDCS)",
-      "register": 40,
-      "register_start": 40,
-      "register_end": 40,
-      "name": "Fault code",
-      "description": "The first 8 registers are the 1",
-      "access": null,
-      "range": null,
-      "unit": "en 69 registers have the",
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3028,
+      "register_start": 3028,
+      "register_end": 3029,
+      "name": "AC phase L1 power",
+      "description": "Active power exported on phase L1.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "fault_code",
         "output_1_power"
-      ],
-      "sensors": [
-        "Fault code",
-        "Output 1 Wattage"
       ]
     },
     {
       "type": "entry",
-      "section": "BD C and BMS information (su pport up to 10 PARALLEL BDCS)",
-      "register": 41,
-      "register_start": 41,
-      "register_end": 41,
-      "name": "Intelligent Power Management temperature",
-      "description": "same data area as 3165-3233, th 108 registers (including 8 regi",
-      "access": null,
-      "range": null,
-      "unit": "eserved, a total of r).",
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3030,
+      "register_start": 3030,
+      "register_end": 3030,
+      "name": "AC phase L2 voltage",
+      "description": "AC output voltage for phase L2.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
       "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
+        "output_2_voltage"
       ]
     },
     {
       "type": "entry",
-      "section": "BD C and BMS information (su pport up to 10 PARALLEL BDCS)",
-      "register": 41,
-      "register_start": 41,
-      "register_end": 41,
-      "name": "Intelligent Power Management temperature",
-      "description": "The first 8 registers are the 1",
-      "access": null,
-      "range": null,
-      "unit": "en 69 registers have the",
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3031,
+      "register_start": 3031,
+      "register_end": 3031,
+      "name": "AC phase L2 current",
+      "description": "AC output current for phase L2.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "ipm_temperature"
-      ],
-      "sensors": [
-        "Intelligent Power Management temperature"
+        "output_2_amperage"
       ]
     },
     {
       "type": "entry",
-      "section": "BD C and BMS information (su pport up to 10 PARALLEL BDCS)",
-      "register": 42,
-      "register_start": 42,
-      "register_end": 42,
-      "name": "Fault code",
-      "description": "same data area as 3165-3233, th 108 registers (including 8 regi",
-      "access": null,
-      "range": null,
-      "unit": "eserved, a total of r).",
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3032,
+      "register_start": 3032,
+      "register_end": 3033,
+      "name": "AC phase L2 power",
+      "description": "Active power exported on phase L2.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
       "attributes": [
-        "fault_code",
-        "output_2_voltage",
-        "p_bus_voltage"
-      ],
-      "sensors": [
-        "Fault code",
-        "Output 2 voltage",
-        "P-bus voltage"
+        "output_2_power"
       ]
     },
     {
-      "type": "section",
-      "title": "…… The first 8 registers are the 1 6-bit serial number of BDC, th en 69 registers have the"
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3034,
+      "register_start": 3034,
+      "register_end": 3034,
+      "name": "AC phase L3 voltage",
+      "description": "AC output voltage for phase L3.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
+      "attributes": [
+        "output_3_voltage"
+      ]
     },
     {
       "type": "entry",
-      "section": "…… The first 8 registers are the 1 6-bit serial number of BDC, th en 69 registers have the",
-      "register": 48,
-      "register_start": 48,
-      "register_end": 48,
-      "name": "Input 1 energy today",
-      "description": "The first 8 registers are the 1",
-      "access": null,
-      "range": null,
-      "unit": "en 69 registers have the",
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3035,
+      "register_start": 3035,
+      "register_end": 3035,
+      "name": "AC phase L3 current",
+      "description": "AC output current for phase L3.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
       "attributes": [
-        "input_1_energy_today",
+        "output_3_amperage"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3036,
+      "register_start": 3036,
+      "register_end": 3037,
+      "name": "AC phase L3 power",
+      "description": "Active power exported on phase L3.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
+      "attributes": [
         "output_3_power"
-      ],
-      "sensors": [
-        "Input 1 energy today",
-        "Output 3 Wattage",
-        "PV1 energy produced today"
       ]
     },
     {
       "type": "entry",
-      "section": "…… The first 8 registers are the 1 6-bit serial number of BDC, th en 69 registers have the",
-      "register": 49,
-      "register_start": 49,
-      "register_end": 49,
-      "name": "71",
-      "description": "same data area as 3165-3233, th 108 registers (including 8 regi",
-      "access": null,
-      "range": null,
-      "unit": "eserved, a total of r).",
-      "initial": null,
-      "note": null
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3041,
+      "register_start": 3041,
+      "register_end": 3042,
+      "name": "Load supply power",
+      "description": "Real-time active power delivered to on-site (self-consumption) loads.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
+      "attributes": [
+        "power_to_user"
+      ]
     },
     {
       "type": "entry",
-      "section": "…… The first 8 registers are the 1 6-bit serial number of BDC, th en 69 registers have the",
-      "register": 49,
-      "register_start": 49,
-      "register_end": 49,
-      "name": "72- 10",
-      "description": "The first 8 registers are the 1",
-      "access": null,
-      "range": null,
-      "unit": "en 69 registers have the",
-      "initial": null,
-      "note": null
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3043,
+      "register_start": 3043,
+      "register_end": 3044,
+      "name": "Grid export power",
+      "description": "Active power exported to the utility grid.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
+      "attributes": [
+        "power_to_grid"
+      ]
     },
     {
       "type": "entry",
-      "section": "…… The first 8 registers are the 1 6-bit serial number of BDC, th en 69 registers have the",
-      "register": 50,
-      "register_start": 50,
-      "register_end": 50,
-      "name": "Input 1 total energy",
-      "description": "same data area as 3165-3233, th 108 registers (including 8 regi",
-      "access": null,
-      "range": null,
-      "unit": "eserved, a total of r).",
-      "initial": null,
-      "note": null,
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3045,
+      "register_start": 3045,
+      "register_end": 3046,
+      "name": "Home load power",
+      "description": "Aggregate instantaneous demand from on-site loads.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt",
+      "attributes": [
+        "power_user_load"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3047,
+      "register_start": 3047,
+      "register_end": 3048,
+      "name": "Run time",
+      "description": "Total cumulative run time of the inverter. Raw values are seconds scaled by 1/7200 (0.0001389 hours).",
+      "access": "R",
+      "unit": "h",
+      "data_type": "u32_runtime_hours",
+      "note": "Raw counter counts seconds; divide by 7200 to obtain hours.",
+      "attributes": [
+        "operation_hours"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3049,
+      "register_start": 3049,
+      "register_end": 3050,
+      "name": "Output energy today",
+      "description": "Energy exported to the AC output today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "output_energy_today"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3051,
+      "register_start": 3051,
+      "register_end": 3052,
+      "name": "Output energy total",
+      "description": "Lifetime AC output energy (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "output_energy_total"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3053,
+      "register_start": 3053,
+      "register_end": 3054,
+      "name": "PV energy total",
+      "description": "Total PV energy generated across all strings (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "input_energy_total"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3055,
+      "register_start": 3055,
+      "register_end": 3056,
+      "name": "PV1 energy today",
+      "description": "Energy harvested by PV1 today. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "input_1_energy_today"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3057,
+      "register_start": 3057,
+      "register_end": 3058,
+      "name": "PV1 energy total",
+      "description": "Lifetime energy harvested by PV1. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
       "attributes": [
         "input_1_energy_total"
-      ],
-      "sensors": [
-        "Input 1 total energy",
-        "PV1 energy produced Lifetime"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3059,
+      "register_start": 3059,
+      "register_end": 3060,
+      "name": "PV2 energy today",
+      "description": "Energy harvested by PV2 today. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "input_2_energy_today"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3061,
+      "register_start": 3061,
+      "register_end": 3062,
+      "name": "PV2 energy total",
+      "description": "Lifetime energy harvested by PV2. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "input_2_energy_total"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3063,
+      "register_start": 3063,
+      "register_end": 3064,
+      "name": "PV3 energy today",
+      "description": "Energy harvested by PV3 today. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "input_3_energy_today"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3065,
+      "register_start": 3065,
+      "register_end": 3066,
+      "name": "PV3 energy total",
+      "description": "Lifetime energy harvested by PV3. Values use 0.1 kWh resolution.",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "input_3_energy_total"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3067,
+      "register_start": 3067,
+      "register_end": 3068,
+      "name": "Load energy today",
+      "description": "Energy delivered to on-site loads today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "energy_to_user_today"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3069,
+      "register_start": 3069,
+      "register_end": 3070,
+      "name": "Load energy total",
+      "description": "Lifetime energy delivered to on-site loads (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "energy_to_user_total"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3071,
+      "register_start": 3071,
+      "register_end": 3072,
+      "name": "Export energy today",
+      "description": "Energy exported to the grid today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "energy_to_grid_today"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3073,
+      "register_start": 3073,
+      "register_end": 3074,
+      "name": "Export energy total",
+      "description": "Lifetime energy exported to the grid (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "energy_to_grid_total"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3086,
+      "register_start": 3086,
+      "register_end": 3086,
+      "name": "Derating mode",
+      "description": "Active derating reason reported by the inverter controller.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw_code",
+      "attributes": [
+        "derating_mode"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3093,
+      "register_start": 3093,
+      "register_end": 3093,
+      "name": "Inverter temperature",
+      "description": "Main inverter heatsink temperature (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "inverter_temperature"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3094,
+      "register_start": 3094,
+      "register_end": 3094,
+      "name": "IPM temperature",
+      "description": "IPM (power module) temperature (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "ipm_temperature"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3095,
+      "register_start": 3095,
+      "register_end": 3095,
+      "name": "Boost temperature",
+      "description": "Boost inductor temperature (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "boost_temperature"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3097,
+      "register_start": 3097,
+      "register_end": 3097,
+      "name": "Communication board temperature",
+      "description": "Temperature reported by the communication/control board (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "comm_board_temperature"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3098,
+      "register_start": 3098,
+      "register_end": 3098,
+      "name": "P-bus voltage",
+      "description": "Positive DC bus voltage (0.1 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
+      "attributes": [
+        "p_bus_voltage"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3099,
+      "register_start": 3099,
+      "register_end": 3099,
+      "name": "N-bus voltage",
+      "description": "Negative DC bus voltage (0.1 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
+      "attributes": [
+        "n_bus_voltage"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3101,
+      "register_start": 3101,
+      "register_end": 3101,
+      "name": "Output power percentage",
+      "description": "Instantaneous AC output as a percentage of the inverter's rated power.",
+      "access": "R",
+      "unit": "%",
+      "data_type": "u16_percent",
+      "attributes": [
+        "real_output_power_percent"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3105,
+      "register_start": 3105,
+      "register_end": 3105,
+      "name": "Fault code",
+      "description": "Current inverter fault code (see protocol documentation).",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_status_word",
+      "attributes": [
+        "fault_code"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3110,
+      "register_start": 3110,
+      "register_end": 3111,
+      "name": "Warning code",
+      "description": "Current inverter warning code (vendor-defined bitmask).",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_status_word",
+      "attributes": [
+        "warning_code"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3111,
+      "register_start": 3111,
+      "register_end": 3111,
+      "name": "Present FFT value (channel A)",
+      "description": "Latest Fast Fourier Transform diagnostic value for channel A.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "present_fft_a"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3115,
+      "register_start": 3115,
+      "register_end": 3115,
+      "name": "Inverter start delay",
+      "description": "Seconds remaining before restart once grid conditions recover.",
+      "access": "R",
+      "unit": "s",
+      "data_type": "u16_raw",
+      "attributes": [
+        "inv_start_delay"
+      ]
+    },
+    {
+      "type": "section",
+      "title": "TL-X/TL-XH battery telemetry (3125–3199)"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3125,
+      "register_start": 3125,
+      "register_end": 3126,
+      "name": "Battery discharge today",
+      "description": "Energy discharged from the battery into the AC system today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "discharge_energy_today"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3127,
+      "register_start": 3127,
+      "register_end": 3128,
+      "name": "Battery discharge total",
+      "description": "Total energy discharged from the battery (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "discharge_energy_total"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3129,
+      "register_start": 3129,
+      "register_end": 3130,
+      "name": "Battery charge today",
+      "description": "Energy charged into the battery today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "charge_energy_today"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3131,
+      "register_start": 3131,
+      "register_end": 3132,
+      "name": "Battery charge total",
+      "description": "Total energy charged into the battery (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth",
+      "attributes": [
+        "charge_energy_total"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3164,
+      "register_start": 3164,
+      "register_end": 3164,
+      "name": "BDC presence flag",
+      "description": "Indicates whether a battery DC converter (BDC) has been detected.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_flag",
+      "attributes": [
+        "bdc_new_flag"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3169,
+      "register_start": 3169,
+      "register_end": 3169,
+      "name": "Battery voltage",
+      "description": "Pack voltage reported via the inverter-side measurements (0.01 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_centivolt",
+      "attributes": [
+        "battery_voltage"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3170,
+      "register_start": 3170,
+      "register_end": 3170,
+      "name": "Battery current",
+      "description": "Current flowing between battery and inverter (positive = discharge) with 0.1 A resolution.",
+      "access": "R",
+      "unit": "A",
+      "data_type": "s16_current_deciamp",
+      "attributes": [
+        "battery_current"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3171,
+      "register_start": 3171,
+      "register_end": 3171,
+      "name": "Battery SOC",
+      "description": "Battery state of charge reported by the inverter.",
+      "access": "R",
+      "unit": "%",
+      "data_type": "u16_percent",
+      "attributes": [
+        "soc"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3172,
+      "register_start": 3172,
+      "register_end": 3172,
+      "name": "VBUS1 voltage",
+      "description": "BDC high-side bus voltage (0.1 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
+      "attributes": [
+        "vbus1_voltage"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3173,
+      "register_start": 3173,
+      "register_end": 3173,
+      "name": "VBUS2 voltage",
+      "description": "BDC low-side bus voltage (0.1 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt",
+      "attributes": [
+        "vbus2_voltage"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3174,
+      "register_start": 3174,
+      "register_end": 3174,
+      "name": "Buck/boost current",
+      "description": "Current through the BDC buck/boost stage (0.1 A resolution).",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
+      "attributes": [
+        "buck_boost_current"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3175,
+      "register_start": 3175,
+      "register_end": 3175,
+      "name": "LLC stage current",
+      "description": "Current through the LLC resonant stage (0.1 A resolution).",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp",
+      "attributes": [
+        "llc_current"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3176,
+      "register_start": 3176,
+      "register_end": 3176,
+      "name": "Battery temperature A",
+      "description": "Battery temperature sensor A (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "battery_temperature_a"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3177,
+      "register_start": 3177,
+      "register_end": 3177,
+      "name": "Battery temperature B",
+      "description": "Battery temperature sensor B (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "battery_temperature_b"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3178,
+      "register_start": 3178,
+      "register_end": 3179,
+      "name": "Battery discharge power",
+      "description": "Real-time discharge power flowing from the battery (0.1 W resolution).",
+      "access": "R",
+      "unit": "W",
+      "data_type": "s32_power_w_decawatt",
+      "attributes": [
+        "discharge_power"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3180,
+      "register_start": 3180,
+      "register_end": 3181,
+      "name": "Battery charge power",
+      "description": "Real-time charge power flowing into the battery (0.1 W resolution).",
+      "access": "R",
+      "unit": "W",
+      "data_type": "s32_power_w_decawatt",
+      "attributes": [
+        "charge_power"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3189,
+      "register_start": 3189,
+      "register_end": 3189,
+      "name": "BMS max cell index",
+      "description": "Cell index reporting the highest voltage in the battery stack (1-based).",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_max_volt_cell_no"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3190,
+      "register_start": 3190,
+      "register_end": 3190,
+      "name": "BMS min cell index",
+      "description": "Cell index reporting the lowest voltage in the battery stack (1-based).",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_min_volt_cell_no"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3191,
+      "register_start": 3191,
+      "register_end": 3191,
+      "name": "BMS average temperature A",
+      "description": "Average temperature reported by sensor group A (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "bms_avg_temp_a"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3192,
+      "register_start": 3192,
+      "register_end": 3192,
+      "name": "BMS max cell temperature A",
+      "description": "Maximum cell temperature within sensor group A (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "bms_max_cell_temp_a"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3193,
+      "register_start": 3193,
+      "register_end": 3193,
+      "name": "BMS average temperature B",
+      "description": "Average temperature reported by sensor group B (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "bms_avg_temp_b"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3194,
+      "register_start": 3194,
+      "register_end": 3194,
+      "name": "BMS max cell temperature B",
+      "description": "Maximum cell temperature within sensor group B (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "bms_max_cell_temp_b"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3195,
+      "register_start": 3195,
+      "register_end": 3195,
+      "name": "BMS average temperature C",
+      "description": "Average temperature reported by sensor group C (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "bms_avg_temp_c"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3196,
+      "register_start": 3196,
+      "register_end": 3196,
+      "name": "BMS max SOC",
+      "description": "Highest state of charge observed across battery modules.",
+      "access": "R",
+      "unit": "%",
+      "data_type": "u16_percent",
+      "attributes": [
+        "bms_max_soc"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3197,
+      "register_start": 3197,
+      "register_end": 3197,
+      "name": "BMS min SOC",
+      "description": "Lowest state of charge observed across battery modules.",
+      "access": "R",
+      "unit": "%",
+      "data_type": "u16_percent",
+      "attributes": [
+        "bms_min_soc"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3198,
+      "register_start": 3198,
+      "register_end": 3198,
+      "name": "Parallel battery count",
+      "description": "Number of battery modules detected in parallel.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "parallel_battery_num"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3199,
+      "register_start": 3199,
+      "register_end": 3199,
+      "name": "BMS derate reason",
+      "description": "Reason code reported by the BMS for power derating.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_derate_reason"
+      ]
+    },
+    {
+      "type": "section",
+      "title": "TL-X/TL-XH BMS diagnostics (3200–3231)"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3200,
+      "register_start": 3200,
+      "register_end": 3200,
+      "name": "BMS full charge capacity",
+      "description": "Full charge capacity (FCC) reported by the battery fuel gauge (Ah).",
+      "access": "R",
+      "unit": "Ah",
+      "data_type": "u16_ampere_hour",
+      "attributes": [
+        "bms_gauge_fcc_ah"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3201,
+      "register_start": 3201,
+      "register_end": 3201,
+      "name": "BMS remaining capacity",
+      "description": "Remaining capacity (RM) reported by the battery fuel gauge (Ah).",
+      "access": "R",
+      "unit": "Ah",
+      "data_type": "u16_ampere_hour",
+      "attributes": [
+        "bms_gauge_rm_ah"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3202,
+      "register_start": 3202,
+      "register_end": 3202,
+      "name": "BMS protect flags 1",
+      "description": "Protection bitmask word 1 from the battery management system.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_protect1"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3203,
+      "register_start": 3203,
+      "register_end": 3203,
+      "name": "BMS warning flags 1",
+      "description": "Warning bitmask word 1 from the battery management system.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_warn1"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3204,
+      "register_start": 3204,
+      "register_end": 3204,
+      "name": "BMS fault flags 1",
+      "description": "Fault bitmask word 1 from the battery management system.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_fault1"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3205,
+      "register_start": 3205,
+      "register_end": 3205,
+      "name": "BMS fault flags 2",
+      "description": "Fault bitmask word 2 from the battery management system.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_fault2"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3210,
+      "register_start": 3210,
+      "register_end": 3210,
+      "name": "Battery insulation status",
+      "description": "Isolation detection status reported by the BMS (0 = not detected, 1 = detected).",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bat_iso_status"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3211,
+      "register_start": 3211,
+      "register_end": 3211,
+      "name": "Battery request flags",
+      "description": "Bitmask of requests from the BMS to the inverter (charge/discharge permissions).",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "batt_request_flags"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3212,
+      "register_start": 3212,
+      "register_end": 3212,
+      "name": "BMS status",
+      "description": "Overall battery management system status code.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_status"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3213,
+      "register_start": 3213,
+      "register_end": 3213,
+      "name": "BMS protect flags 2",
+      "description": "Protection bitmask word 2 from the battery management system.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_protect2"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3214,
+      "register_start": 3214,
+      "register_end": 3214,
+      "name": "BMS warning flags 2",
+      "description": "Warning bitmask word 2 from the battery management system.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_warn2"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3215,
+      "register_start": 3215,
+      "register_end": 3215,
+      "name": "BMS SOC",
+      "description": "State of charge reported directly by the BMS.",
+      "access": "R",
+      "unit": "%",
+      "data_type": "u16_percent",
+      "attributes": [
+        "bms_soc"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3216,
+      "register_start": 3216,
+      "register_end": 3216,
+      "name": "BMS battery voltage",
+      "description": "Pack voltage reported by the BMS (0.01 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_centivolt",
+      "attributes": [
+        "bms_battery_voltage"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3217,
+      "register_start": 3217,
+      "register_end": 3217,
+      "name": "BMS battery current",
+      "description": "Current reported by the BMS with 0.01 A resolution (positive = discharge).",
+      "access": "R",
+      "unit": "A",
+      "data_type": "s16_current_centiamp",
+      "note": "Positive values indicate discharge from the battery; negative values indicate charging.",
+      "attributes": [
+        "bms_battery_current"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3218,
+      "register_start": 3218,
+      "register_end": 3218,
+      "name": "BMS max cell temperature",
+      "description": "Maximum cell temperature observed across the battery pack (0.1 °C resolution).",
+      "access": "R",
+      "unit": "°C",
+      "data_type": "s16_temperature_decic",
+      "attributes": [
+        "bms_cell_max_temp"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3219,
+      "register_start": 3219,
+      "register_end": 3219,
+      "name": "BMS max charge current",
+      "description": "Maximum charge current allowed by the BMS (0.01 A resolution).",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_centiamp",
+      "attributes": [
+        "bms_max_charge_current"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3220,
+      "register_start": 3220,
+      "register_end": 3220,
+      "name": "BMS max discharge current",
+      "description": "Maximum discharge current allowed by the BMS (0.01 A resolution).",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_centiamp",
+      "attributes": [
+        "bms_max_discharge_current"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3221,
+      "register_start": 3221,
+      "register_end": 3221,
+      "name": "BMS cycle count",
+      "description": "Total charge/discharge cycles counted by the BMS.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_cycle_count"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3222,
+      "register_start": 3222,
+      "register_end": 3222,
+      "name": "BMS state of health",
+      "description": "Battery state of health reported by the BMS.",
+      "access": "R",
+      "unit": "%",
+      "data_type": "u16_percent",
+      "attributes": [
+        "bms_soh"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3223,
+      "register_start": 3223,
+      "register_end": 3223,
+      "name": "BMS charge voltage limit",
+      "description": "Maximum pack voltage permitted during charge (0.01 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_centivolt",
+      "attributes": [
+        "bms_charge_volt_limit"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3224,
+      "register_start": 3224,
+      "register_end": 3224,
+      "name": "BMS discharge voltage limit",
+      "description": "Minimum pack voltage permitted during discharge (0.01 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_centivolt",
+      "attributes": [
+        "bms_discharge_volt_limit"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3225,
+      "register_start": 3225,
+      "register_end": 3225,
+      "name": "BMS warning flags 3",
+      "description": "Warning bitmask word 3 from the battery management system.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_warn3"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3226,
+      "register_start": 3226,
+      "register_end": 3226,
+      "name": "BMS protect flags 3",
+      "description": "Protection bitmask word 3 from the battery management system.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw",
+      "attributes": [
+        "bms_protect3"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3230,
+      "register_start": 3230,
+      "register_end": 3230,
+      "name": "BMS max cell voltage",
+      "description": "Highest individual cell voltage (0.001 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_millivolt",
+      "attributes": [
+        "bms_cell_volt_max"
+      ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "register": 3231,
+      "register_start": 3231,
+      "register_end": 3231,
+      "name": "BMS min cell voltage",
+      "description": "Lowest individual cell voltage (0.001 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_millivolt",
+      "attributes": [
+        "bms_cell_volt_min"
       ]
     }
   ]

--- a/doc/growatt_registers_spec.md
+++ b/doc/growatt_registers_spec.md
@@ -16,15 +16,15 @@ This file is generated from `growatt_registers_spec.json` (parsed from the offic
 | TL3/MAX/MID/MAC Holding Registers (125–249) | 80 | 0 | 80 |
 | Storage Holding Registers (1000–1124) | 35 | 0 | 35 |
 | Storage Holding Registers (1125–1249) | 15 | 0 | 15 |
-| Common Input Registers (0–124) | 100 | 80 | 20 |
-| TL-X/TL-XH Input Registers (3000–3124) | 0 | 0 | 0 |
-| TL-X/TL-XH Battery & Hybrid Input Registers (3125–3249) | 0 | 0 | 0 |
+| Common Input Registers (0–124) | 66 | 66 | 0 |
+| TL-X/TL-XH Input Registers (3000–3124) | 55 | 55 | 0 |
+| TL-X/TL-XH Battery & Hybrid Input Registers (3125–3249) | 52 | 52 | 0 |
 | TL-X/TL-XH Extended Input Registers (3250–3374) | 0 | 0 | 0 |
 | Storage Input Registers (1000–1124) | 0 | 0 | 0 |
 | Storage Input Registers (1125–1249) | 0 | 0 | 0 |
 | Storage Input Registers (2000–2124) | 0 | 0 | 0 |
-| Storage TL-XH Input Registers (3041–3231) | 0 | 0 | 0 |
-| Offgrid SPF Input Registers | 100 | 41 | 59 |
+| Storage TL-XH Input Registers (3041–3231) | 81 | 62 | 19 |
+| Offgrid SPF Input Registers | 175 | 25 | 150 |
 
 ## Common Holding Registers (0–124)
 Applies to TL-X/TL-XH, TL3/MAX/MID/MAC, and MIX/SPA/SPH storage families.
@@ -404,890 +404,284 @@ Applies to TL3/MAX and legacy inverters for basic PV/AC telemetry.
 
 | Register | Name | Description | Access | Range/Unit | Initial | Notes | Attributes | Sensors |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 0 | Status code | Inverter run state | — | — | — | — | tlx:status_code, tl3:status_code, offgrid:status_code | Status code |
-| 1 | Input 1 voltage | Input power (high) | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 2 | Input 2 voltage | Input power (low) | — | — | — | — | offgrid:input_2_voltage | Input 2 voltage, PV2 voltage |
-| 3 | Input 1 Wattage | PV 1 voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 4 | Input 1 Amperage | PV 1 input current | — | — | — | — | tlx:input_1_amperage, tl3:input_1_amperage | Input 1 Amperage, PV1 buck current |
-| 5 | Input 1 Wattage | PV 1 input power(high) | — | — | — | — | tlx:input_1_power, tl3:input_1_power, offgrid:input_2_power | Input 1 Wattage, Input 2 Wattage, PV1 charge power, PV2 charge power |
-| 6 | Ppv 1 L | PV 1 input power(low) | — | — | — | — | — | — |
-| 7 | Input 1 Amperage | PV 2 voltage | — | — | — | — | tlx:input_2_voltage, tl3:input_2_voltage, offgrid:input_1_amperage | Input 1 Amperage, Input 2 voltage, PV1 buck current, PV2 voltage |
-| 8 | Input 2 Amperage | PV 2 input current | — | — | — | — | tlx:input_2_amperage, tl3:input_2_amperage, offgrid:input_2_amperage | Input 2 Amperage, PV2 buck current |
-| 9 | Input 2 Wattage | PV 2 input power (high) | — | — | — | — | tlx:input_2_power, tl3:input_2_power, offgrid:output_active_power | Input 2 Wattage, Output active power, PV2 charge power |
-| 10 | . Ppv 2 L | PV 2 input power (low) | — | — | — | — | — | — |
-| 11 | Input 3 voltage | PV 3 voltage | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 12 | Input 3 Amperage | PV 3 input current | — | — | — | — | tlx:input_3_amperage | Input 3 Amperage |
-| 13 | AC frequency | PV 3 input power (high) | — | — | — | — | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
-| 14 | Output 1 voltage | PV 3 input power (low) | — | — | — | — | tl3:output_1_voltage | Output 1 voltage, Output voltage |
-| 15 | Input 4 voltage | PV 4 voltage | — | — | — | — | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
-| 16 | Input 4 Amperage | PV 4 input current | — | — | — | — | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
-| 17 | Battery voltage | PV 4 input power (high) | — | — | — | — | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
-| 18 | Output 2 voltage | PV 4 input power (low) | — | — | — | — | tl3:output_2_voltage, offgrid:soc | Output 2 voltage, SOC |
-| 19 | Bus voltage | PV 5 voltage | — | — | — | — | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
-| 20 | Grid voltage | PV 5 input current | — | — | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 21 | AC frequency | PV 5 input power(high) | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 22 | Output 1 voltage | PV 5 input power(low) | — | — | — | — | tl3:output_3_voltage, offgrid:output_1_voltage | Output 1 voltage, Output 3 voltage, Output voltage |
-| 23 | Input 6 voltage | PV 6 voltage | — | — | — | — | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
-| 24 | Input 6 Amperage | PV 6 input current | — | — | — | — | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
-| 25 | Input 6 Wattage | PV 6 input power (high) | — | — | — | — | tlx:input_6_power, offgrid:inverter_temperature | Input 6 Wattage, Temperature |
-| 26 | DC-DC temperature | PV 6 input power (low) | — | — | — | — | tl3:output_energy_today, offgrid:dc_dc_temperature | DC-DC temperature, Energy produced today |
-| 27 | Input 7 voltage | PV 7 voltage | — | — | — | — | tlx:input_7_voltage, offgrid:load_percent | Input 7 voltage, Inverter load |
-| 28 | Battery port voltage | PV 7 input current | — | — | — | — | tlx:input_7_amperage, tl3:output_energy_total, offgrid:battery_port_voltage | Battery port voltage, Input 7 Amperage, Total energy produced |
-| 29 | Battery bus voltage | PV 7 input power (high) | — | — | — | — | tlx:input_7_power, offgrid:battery_bus_voltage | Battery bus voltage, Input 7 Wattage |
-| 30 | Running hours | PV 7 input power (low) | — | — | — | — | tl3:operation_hours, offgrid:operation_hours | Running hours |
-| 31 | Input 8 voltage | PV 8 voltage | — | — | — | — | tlx:input_8_voltage | Input 8 voltage |
-| 32 | Input 8 Amperage | PV 8 input current | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 33 | Input 8 Wattage | PV 8 input power (high) | — | — | — | — | tlx:input_8_power | Input 8 Wattage |
-| 34 | Output 1 Amperage | PV 8 input power (low) | — | — | — | — | offgrid:output_1_amperage | Output 1 Amperage, Output amperage |
-| 35 | Output power | Output power (high) | — | — | — | — | tlx:output_power | Output power |
-| 36 | . Pac L | Output power (low) | — | — | — | — | — | — |
-| 37 | AC frequency | Grid frequency | — | — | — | — | tlx:grid_frequency | AC frequency, Grid frequency |
-| 38 | Output 1 voltage | Three/single phase grid voltage | — | — | — | — | tlx:output_1_voltage | Output 1 voltage, Output voltage |
-| 39 | Output 1 Amperage | Three/single phase grid output | — | — | — | — | tlx:output_1_amperage | Output 1 Amperage, Output amperage |
-| 40 | Fault code | Three/single phase grid output VA (high) | — | — | — | — | tlx:output_1_power, tl3:fault_code | Fault code, Output 1 Wattage |
-| 41 | Intelligent Power Management temperature | Three/single phase grid output VA(low) | — | — | — | — | tl3:ipm_temperature | Intelligent Power Management temperature |
-| 42 | Fault code | Three phase grid voltage | — | — | — | — | tlx:output_2_voltage, tl3:p_bus_voltage, offgrid:fault_code | Fault code, Output 2 voltage, P-bus voltage |
-| 43 | N-bus voltage | Three phase grid output current | — | — | — | — | tlx:output_2_amperage, tl3:n_bus_voltage, offgrid:warning_code | N-bus voltage, Output 2 Amperage, Warning code |
-| 44 | Output 2 Wattage | Three phase grid output power ( | — | — | — | — | tlx:output_2_power | Output 2 Wattage |
-| 45 | . Pac 2 L | Three phase grid output power ( | — | — | — | — | — | — |
-| 46 | Output 3 voltage | Three phase grid voltage | — | — | — | — | tlx:output_3_voltage | Output 3 voltage |
-| 47 | Derating mode | Three phase grid output current | — | — | — | — | tlx:output_3_amperage, tl3:derating_mode, offgrid:constant_power | Derating mode, Output 3 Amperage |
-| 48 | Input 1 energy today | Three phase grid output power ( | — | — | — | — | tlx:output_3_power, tl3:input_1_energy_today, offgrid:input_1_energy_today | Input 1 energy today, Output 3 Wattage, PV1 energy produced today |
-| 49 | . Pac 3 L | Three phase grid output power ( | — | — | — | — | — | — |
-| 50 | Input 1 total energy | Three phase grid voltage | — | — ne voltage | — | — | tl3:input_1_energy_total, offgrid:input_1_energy_total | Input 1 total energy, PV1 energy produced Lifetime |
-| 51 | . Vac_ST | Three phase grid voltage | — | — ne voltage | — | — | — | — |
-| 52 | Input 2 energy today | Three phase grid voltage | — | — ne voltage | — | — | tl3:input_2_energy_today, offgrid:input_2_energy_today | Input 2 energy today, PV2 energy produced today |
-| 53 | Energy produced today | Today generate energy (high) | — | — | — | — | tlx:output_energy_today | Energy produced today |
-| 54 | Input 2 total energy | Today generate energy (low) | — | — | — | — | tl3:input_2_energy_total, offgrid:input_2_energy_total | Input 2 total energy, PV2 energy produced Lifetime |
-| 55 | Total energy produced | Total generate energy (high) | — | — | — | — | tlx:output_energy_total | Total energy produced |
-| 56 | Battery Charged (Today) | Total generate energy (low) | — | — | — | — | tl3:input_energy_total, offgrid:charge_energy_today | Battery Charged (Today), Battery Charged Today, Total energy input |
-| 57 | Running hours | Work time total (high) | — | — | — | — | tlx:operation_hours | Running hours |
-| 58 | Battery Charged (Total) | Work time total (low) | — | — | — | — | tl3:output_reactive_power, offgrid:charge_energy_total | Battery Charged (Total), Grid Charged Lifetime, Reactive wattage |
-| 59 | Input 1 energy today | PV 1 Energy today(high) | — | — | — | — | tlx:input_1_energy_today | Input 1 energy today, PV1 energy produced today |
-| 60 | Battery Discharged (Today) | PV 1 Energy today (low) | — | — | — | — | tl3:output_reactive_energy_today, offgrid:discharge_energy_today | Battery Discharged (Today), Battery Discharged Today |
-| 61 | Input 1 total energy | PV 1 Energy total(high) | — | — | — | — | tlx:input_1_energy_total | Input 1 total energy, PV1 energy produced Lifetime |
-| 62 | Battery Discharged (Total) | PV 1 Energy total (low) | — | — | — | — | tl3:output_reactive_energy_total, offgrid:discharge_energy_total | Battery Discharged (Total), Battery Discharged Lifetime |
-| 63 | Input 2 energy today | PV 2 Energy today(high) | — | — | — | — | tlx:input_2_energy_today | Input 2 energy today, PV2 energy produced today |
-| 64 | AC Discharged Today | PV 2 Energy today (low) | — | — h | — | — | tl3:warning_code, offgrid:ac_discharge_energy_today | AC Discharged Today, Warning code |
-| 65 | Input 2 total energy | PV 2 Energy total(high) | — | — h | — | — | tlx:input_2_energy_total, tl3:warning_value | Input 2 total energy, PV2 energy produced Lifetime |
-| 66 | Grid Discharged Lifetime | PV 2 Energy total (low) | — | — h | — | — | tl3:real_output_power_percent, offgrid:ac_discharge_energy_total | Grid Discharged Lifetime, Real power output percentage |
-| 67 | Input 3 energy today | PV 3 Energy today(high) | — | — h | — | — | tlx:input_3_energy_today | Input 3 energy today |
-| 68 | AC charge battery current | PV 3 Energy today (low) | — | — h | — | — | offgrid:ac_charge_amperage | AC charge battery current |
-| 69 | Battery discharge power | PV 3 Energy total(high) | — | — h | — | — | tlx:input_3_energy_total, offgrid:discharge_power | Battery discharge power, Discharge Power, Input 3 total energy |
-| 70 | . Epv 3_total L | PV 3 Energy total (low) | — | — h | — | — | — | — |
-| 71 | Input 4 energy today | PV 4 Energy today(high) | — | — h | — | — | tlx:input_4_energy_today | Input 4 energy today |
-| 72 | . Epv 4_today L | PV 4 Energy today (low) | — | — h | — | — | — | — |
-| 73 | Battery discharge current | PV 4 Energy total(high) | — | — h | — | — | tlx:input_4_energy_total, offgrid:battery_discharge_amperage | Battery discharge current, Input 4 total energy |
-| 74 | . Epv 4_total L | PV 4 Energy total (low) | — | — h | — | — | — | — |
-| 75 | Input 5 energy today | PV 5 Energy today(high) | — | — h | — | — | tlx:input_5_energy_today | Input 5 energy today |
-| 76 | . Epv 5_today L | PV 5 Energy today (low) | — | — h | — | — | — | — |
-| 77 | Battery charging/ discharging(-ve) | PV 5 Energy total(high) | — | — h | — | — | tlx:input_5_energy_total, offgrid:battery_power | Battery charging/ discharging(-ve), Input 5 total energy |
-| 78 | . Epv 5_total L | PV 5 Energy total (low) | — | — h | — | — | — | — |
-| 79 | Input 6 energy today | PV 6 Energy today(high) | — | — h | — | — | tlx:input_6_energy_today | Input 6 energy today |
-| 80 | . Epv 6_today L | PV 6 Energy today (low) | — | — h | — | — | — | — |
-| 81 | Input 6 total energy | PV 6 Energy total(high) | — | — h | — | — | tlx:input_6_energy_total | Input 6 total energy |
-| 82 | . Epv 6_total L | PV 6 Energy total (low) | — | — h | — | — | — | — |
-| 83 | Input 7 energy today | PV 7 Energy today(high) | — | — h | — | — | tlx:input_7_energy_today | Input 7 energy today |
-| 84 | . Epv 7_today L | PV 7 Energy today (low) | — | — h | — | — | — | — |
-| 85 | Input 7 total energy | PV 7 Energy total(high) | — | — h | — | — | tlx:input_7_energy_total | Input 7 total energy |
-| 86 | . Epv 7_total L | PV 7 Energy total (low) | — | — h | — | — | — | — |
-| 87 | Input 8 energy today | PV 8 Energy today(high) | — | — h | — | — | tlx:input_8_energy_today | Input 8 energy today |
-| 88 | . Epv 8_today L | PV 8 Energy today (low) | — | — h | — | — | — | — |
-| 89 | Input 8 total energy | PV 8 Energy total(high) | — | — h | — | — | tlx:input_8_energy_total | Input 8 total energy |
-| 90 | . Epv 8_total L | PV 8 Energy total (low) | — | — h | — | — | — | — |
-| 91 | Total energy input | PV Energy total(high) | — | — h | — | — | tlx:input_energy_total | Total energy input |
-| 92 | . Epv_total L | PV Energy total (low) | — | — h | — | — | — | — |
-| 93 | Temperature | Inverter temperature | — | — | — | — | tlx:inverter_temperature | Temperature |
-| 94 | Intelligent Power Management temperature | The inside IPM in inverter Temp | — | — | — | — | tlx:ipm_temperature | Intelligent Power Management temperature |
-| 95 | Boost temperature | Boost temperature | — | — | — | — | tlx:boost_temperature | Boost temperature |
-| 96 | . Temp 4 | — | — | — reserved | — | — | — | — |
-| 97 | . uw Bat Volt_DSP | Bat Volt_DSP | — | — Bat Volt(DSP) | — | — | — | — |
-| 98 | P-bus voltage | P Bus inside Voltage | — | — | — | — | tlx:p_bus_voltage | P-bus voltage |
-| 99 | N-bus voltage | N Bus inside Voltage | — | — | — | — | tlx:n_bus_voltage | N-bus voltage |
-| 10 | 0. IPF | Inverter output PF now | — | — | — | — | — | — |
-| 10 | 1. Real OPPercent | Real Output power Percent | — | — | — | — | — | — |
-| 10 | 2. OPFullwatt H | Output Maxpower Limited high | — | — | — | — | — | — |
-| 10 | 3. OPFullwatt L | Output Maxpower Limited low | — | — | — | — | — | — |
-| 10 | 4. Derating Mode | Derating Mode 0 1 2 3 4 5 6 7 8 9 B | — | — | — | — | — | — |
-| 10 | 5. Fault Maincode | Inverter fault maincode | — | — | — | — | — | — |
-| 10 | 6. | — | — | — | — | — | — | — |
-| 10 | 7. Fault Subcode | Inverter fault subcode | — | — | — | — | — | — |
-| 10 | 8. Remote Ctrl En | / 0 1 | — | — orage Pow (SPA) | — | — | — | — |
-| 10 | 9. Remote Ctrl Pow er | / 2 | — | — orage Pow (SPA) | — | — | — | — |
-| 11 | Input 3 voltage | Warning bit H | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Inverter warn subcode | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Inverter warn maincode ACCharge energy today | — | — orage wer | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | real Power Percent 0 ACCharge energy today | — | — X orage wer | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | nv start delay time ACCharge energy total | — | — X orage wer | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | b INVAll Fault Code ACCharge energy total | — | — X orage wer | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Grid power to local load | — | — orage wer | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Grid power to local load | — | — orage wer | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | 0:Load First 1:Battery First 2:Grid First | — | — orage Power | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | 0:Lead-acid 1:Lithium battery | — | — Storage Power | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 12 | Input 3 Amperage | Aging mode Auto-cal command | — | — Storage Power | — | — | tlx:input_3_amperage | Input 3 Amperage |
-| 12 | Input 3 Amperage | — | — | — reserved | — | — | tlx:input_3_amperage | Input 3 Amperage |
-| 12 | Input 3 Amperage | PID PV 1 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | tlx:input_3_amperage | Input 3 Amperage |
-| 12 | Input 3 Amperage | PID PV 1 PE Curr | — | — m A | — | — | tlx:input_3_amperage | Input 3 Amperage |
-| 12 | Input 3 Amperage | PID PV 2 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | tlx:input_3_amperage | Input 3 Amperage |
-| 12 | Input 3 Amperage | PID PV 2 PE Curr | — | — m A | — | — | tlx:input_3_amperage | Input 3 Amperage |
-| 12 | Input 3 Amperage | PID PV 3 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | tlx:input_3_amperage | Input 3 Amperage |
-| 13 | AC frequency | PID PV 3 PE Curr | — | — m A | — | — | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
-| 13 | AC frequency | PID PV 4 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
-| 13 | AC frequency | PID PV 4 PE Curr | — | — m A | — | — | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
-| 13 | AC frequency | PID PV 5 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
-| 13 | AC frequency | PID PV 5 PE Curr | — | — m A | — | — | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
-| 13 | AC frequency | PID PV 6 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
-| 13 | AC frequency | PID PV 6 PE Curr | — | — m A | — | — | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
-| 13 | AC frequency | PID PV 7 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
-| 13 | AC frequency | PID PV 7 PE Curr | — | — m A | — | — | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
-| 13 | AC frequency | PID PV 8 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
-| 14 | Output 1 voltage | PID PV 8 PE Curr | — | — m A | — | — | tl3:output_1_voltage | Output 1 voltage, Output voltage |
-| 14 | Output 1 voltage | Bit 0~7:PID Working Status 1:Wait Status 2:Normal Status 3:Fault Status Bit 8~15:Reversed | — | — | — | — | tl3:output_1_voltage | Output 1 voltage, Output voltage |
-| 14 | Output 1 voltage | PV String 1 voltage | — | — V | — | — | tl3:output_1_voltage | Output 1 voltage, Output voltage |
-| 14 | Output 1 voltage | PV String 1 current | — | — A | — | — | tl3:output_1_voltage | Output 1 voltage, Output voltage |
-| 14 | Output 1 voltage | PV String 2 voltage | — | — V | — | — | tl3:output_1_voltage | Output 1 voltage, Output voltage |
-| 14 | Output 1 voltage | PV String 2 current | — | — | — | — | tl3:output_1_voltage | Output 1 voltage, Output voltage |
-| 14 | Output 1 voltage | PV String 3 voltage | — | — | — | — | tl3:output_1_voltage | Output 1 voltage, Output voltage |
-| 14 | Output 1 voltage | PV String 3 current | — | — | — | — | tl3:output_1_voltage | Output 1 voltage, Output voltage |
-| 14 | Output 1 voltage | PV String 4 voltage | — | — | — | — | tl3:output_1_voltage | Output 1 voltage, Output voltage |
-| 14 | Output 1 voltage | PV String 4 current | — | — | — | — | tl3:output_1_voltage | Output 1 voltage, Output voltage |
-| 15 | Input 4 voltage | PV String 5 voltage | — | — | — | — | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
-| 15 | Input 4 voltage | PV String 5 current | — | — | — | — | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
-| 15 | Input 4 voltage | PV String 6 voltage | — | — | — | — | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
-| 15 | Input 4 voltage | PV String 6 current | — | — | — | — | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
-| 15 | Input 4 voltage | PV String 7 voltage | — | — | — | — | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
-| 15 | Input 4 voltage | PV String 7 current | — | — | — | — | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
-| 15 | Input 4 voltage | PV String 8 voltage | — | — | — | — | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
-| 15 | Input 4 voltage | PV String 8 current | — | — | — | — | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
-| 15 | Input 4 voltage | PV String 9 voltage | — | — | — | — | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
-| 15 | Input 4 voltage | PV String 9 current | — | — | — | — | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
-| 16 | Input 4 Amperage | PV String 10 voltage | — | — | — | — | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
-| 16 | Input 4 Amperage | PV String 10 current | — | — | — | — | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
-| 16 | Input 4 Amperage | PV String 11 voltage | — | — | — | — | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
-| 16 | Input 4 Amperage | PV String 11 current | — | — | — | — | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
-| 16 | Input 4 Amperage | PV String 12 voltage | — | — | — | — | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
-| 16 | Input 4 Amperage | PV String 12 current | — | — | — | — | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
-| 16 | Input 4 Amperage | PV String 13 voltage | — | — | — | — | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
-| 16 | Input 4 Amperage | PV String 13 current | — | — | — | — | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
-| 16 | Input 4 Amperage | PV String 14 voltage | — | — | — | — | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
-| 16 | Input 4 Amperage | PV String 14 current | — | — | — | — | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
-| 17 | Battery voltage | PV String 15 voltage | — | — | — | — | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
-| 17 | Battery voltage | PV String 15 current | — | — | — | — | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
-| 17 | Battery voltage | PV String 16 voltage | — | — | — | — | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
-| 17 | Battery voltage | PV String 16 current | — | — | — | — | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
-| 17 | Battery voltage | Bit 0~15: String 1~16 unmatch | — | — suggestive | — | — | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
-| 17 | Battery voltage | Bit 0~15: String 1~16 current u | — | — suggestive | — | — | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
-| 17 | Battery voltage | Bit 0~15: String 1~16 disconnec | — | — suggestive | — | — | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
-| 17 | Battery voltage | Bit 0:Output over voltage Bit 1: ISO fault Bit 2: BUS voltage abnormal Bit 3~15:reserved | — | — | — | — | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
-| 17 | Battery voltage | String Prompt Bit 0:String Unmatch Bit 1:Str Disconnect Bit 2:Str Current Unblance Bit 3~15:reserved | — | — | — | — | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
-| 17 | Battery voltage | PV Warning Value | — | — | — | — | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
-| 18 | Output 2 voltage | DSP 075 Warning Value | — | — | — | — | tl3:output_2_voltage, offgrid:soc | Output 2 voltage, SOC |
-| 18 | Output 2 voltage | ult DSP 075 Fault Value | — | — | — | — | tl3:output_2_voltage, offgrid:soc | Output 2 voltage, SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 1 | — | — | — | — | tl3:output_2_voltage, offgrid:soc | Output 2 voltage, SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 2 | — | — | — | — | tl3:output_2_voltage, offgrid:soc | Output 2 voltage, SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 3 | — | — | — | — | tl3:output_2_voltage, offgrid:soc | Output 2 voltage, SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 4 | — | — | — | — | tl3:output_2_voltage, offgrid:soc | Output 2 voltage, SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 5 | — | — | — | — | tl3:output_2_voltage, offgrid:soc | Output 2 voltage, SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 6 | — | — | — | — | tl3:output_2_voltage, offgrid:soc | Output 2 voltage, SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 7 | — | — | — | — | tl3:output_2_voltage, offgrid:soc | Output 2 voltage, SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 8 | — | — | — | — | tl3:output_2_voltage, offgrid:soc | Output 2 voltage, SOC |
-| 19 | Bus voltage | g DSP 075 Debug Data 1 | — | — | — | — | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
-| 19 | Bus voltage | g DSP 075 Debug Data 2 | — | — | — | — | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
-| 19 | Bus voltage | g DSP 075 Debug Data 3 | — | — | — | — | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
-| 19 | Bus voltage | g DSP 075 Debug Data 4 | — | — | — | — | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
-| 19 | Bus voltage | g DSP 075 Debug Data 5 | — | — | — | — | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
-| 19 | Bus voltage | g DSP 075 Debug Data 6 | — | — | — | — | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
-| 19 | Bus voltage | g DSP 075 Debug Data 7 | — | — | — | — | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
-| 19 | Bus voltage | g DSP 075 Debug Data 8 | — | — | — | — | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
-| 19 | Bus voltage | USBAging Test Ok Flag 0-1 | — | — | — | — | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
-| 19 | Bus voltage | Flash Erase Aging Ok Flag 0-1 | — | — | — | — | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
-| 20 | Grid voltage | PVISOValue | — | — | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | R DCI Curr | — | — | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | S DCI Curr | — | — | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | T DCI Curr | — | — | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | PIDBus Volt | — | — | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | GFCI Curr | — | — | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | SVG/APF Status+SVGAPFEqual Rat | — | — | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | R phase load side current for | — | — | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | S phase load side current for | — | — | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | T phase load side current for | — | — | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 21 | AC frequency | R phase load side output reac power for SVG(High) | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | R phase load side output reac power for SVG(low) | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | S phase load side output reac power for SVG(High) | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | S phase load side output reac power for SVG(low) | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | T phase load side output reac power for SVG(High) | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | T phase load side output reac power for SVG(low) | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | R phase load side harmonic | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | S phase load side harmonic | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | T phase load side harmonic | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | R phase compensate reactive p for SVG(High) | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 22 | Output 1 voltage | R phase compensate reactive p for SVG(low) | — | — | — | — | tl3:output_3_voltage, offgrid:output_1_voltage | Output 1 voltage, Output 3 voltage, Output voltage |
-| 22 | Output 1 voltage | S phase compensate reactive p for SVG(High) | — | — | — | — | tl3:output_3_voltage, offgrid:output_1_voltage | Output 1 voltage, Output 3 voltage, Output voltage |
-| 22 | Output 1 voltage | S phase compensate reactive p for SVG(low) | — | — | — | — | tl3:output_3_voltage, offgrid:output_1_voltage | Output 1 voltage, Output 3 voltage, Output voltage |
-| 22 | Output 1 voltage | T phase compensate reactive p for SVG(High) | — | — | — | — | tl3:output_3_voltage, offgrid:output_1_voltage | Output 1 voltage, Output 3 voltage, Output voltage |
-| 22 | Output 1 voltage | T phase compensate reactive p for SVG(low) | — | — | — | — | tl3:output_3_voltage, offgrid:output_1_voltage | Output 1 voltage, Output 3 voltage, Output voltage |
-| 22 | Output 1 voltage | R phase compensate harmonic f SVG | — | — | — | — | tl3:output_3_voltage, offgrid:output_1_voltage | Output 1 voltage, Output 3 voltage, Output voltage |
-| 22 | Output 1 voltage | S phase compensate harmonic f SVG | — | — | — | — | tl3:output_3_voltage, offgrid:output_1_voltage | Output 1 voltage, Output 3 voltage, Output voltage |
-| 22 | Output 1 voltage | T phase compensate harmonic f SVG | — | — | — | — | tl3:output_3_voltage, offgrid:output_1_voltage | Output 1 voltage, Output 3 voltage, Output voltage |
-| 22 | Output 1 voltage | RS 232 Aging Test Ok Flag | — | — | — | — | tl3:output_3_voltage, offgrid:output_1_voltage | Output 1 voltage, Output 3 voltage, Output voltage |
-| 22 | Output 1 voltage | Bit 0: Fan 1 fault bit Bit 1: Fan 2 fault bit Bit 2: Fan 3 fault bit Bit 3: Fan 4 fault bit Bit 4-7: Reserved | — | — | — | — | tl3:output_3_voltage, offgrid:output_1_voltage | Output 1 voltage, Output 3 voltage, Output voltage |
-| 23 | Input 6 voltage | Output apparent power H | — | — | — | — | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
-| 23 | Input 6 voltage | Output apparent power L | — | — | — | — | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
-| 23 | Input 6 voltage | Real Output Reactive Power H | — | — | — | — | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
-| 23 | Input 6 voltage | Real Output Reactive Power L | — | — | — | — | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
-| 23 | Input 6 voltage | Nominal Output Reactive Power | — | — | — | — | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
-| 23 | Input 6 voltage | Nominal Output Reactive Power | — | — | — | — | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
-| 23 | Input 6 voltage | Reactive power generation | — | — | — | — | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
-| 23 | Input 6 voltage | Reactive power generation | — | — | — | — | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
-| 23 | Input 6 voltage | 0:Waiting 1:Self-check state 2:Detect pull arc state 3:Fault 4:Update | — | — | — | — | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
-| 23 | Input 6 voltage | Present FFTValue [CHANNEL_A] | — | — | — | — | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
-| 24 | Input 6 Amperage | Present FFTValue [CHANNEL_B] | — | — | — | — | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
-| 24 | Input 6 Amperage | ug DSP 067 Debug Data 1 | — | — | — | — | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
-| 24 | Input 6 Amperage | ug DSP 067 Debug Data 2 | — | — | — | — | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
-| 24 | Input 6 Amperage | ug DSP 067 Debug Data 3 | — | — | — | — | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
-| 24 | Input 6 Amperage | g DSP 067 Debug Data 4 | — | — | — | — | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
-| 24 | Input 6 Amperage | g DSP 067 Debug Data 5 | — | — | — | — | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
-| 24 | Input 6 Amperage | g DSP 067 Debug Data 6 | — | — | — | — | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
-| 24 | Input 6 Amperage | g DSP 067 Debug Data 7 | — | — | — | — | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
-| 24 | Input 6 Amperage | g DSP 067 Debug Data 8 | — | — | — | — | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
-| 24 | Input 6 Amperage | — | — | — | — | — | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
-| 87 | Input 8 energy today | PV 9 voltage | — | — | — | — | tlx:input_8_energy_today | Input 8 energy today |
-| 87 | Input 8 energy today | PV 9 Input current | — | — | — | — | tlx:input_8_energy_today | Input 8 energy today |
-| 87 | Input 8 energy today | PV 9 input power (High) | — | — | — | — | tlx:input_8_energy_today | Input 8 energy today |
-| 87 | Input 8 energy today | PV 9 input power (Low) | — | — | — | — | tlx:input_8_energy_today | Input 8 energy today |
-| 87 | Input 8 energy today | PV 10 voltage | — | — | — | — | tlx:input_8_energy_today | Input 8 energy today |
-| 88 | 0 PV 10 Curr | PV 10 Input current | — | — | — | — | — | — |
-| 88 | 1 Ppv 10 H | PV 10 input power (High) | — | — | — | — | — | — |
-| 88 | 2 Ppv 10 L | PV 10 input power (Low) | — | — | — | — | — | — |
-| 88 | 3 Vpv 11 | PV 11 voltage | — | — | — | — | — | — |
-| 88 | 4 PV 11 Curr | PV 11 Input current | — | — | — | — | — | — |
-| 88 | 5 Ppv 11 H | PV 11 input power (High) | — | — | — | — | — | — |
-| 88 | 6 Ppv 11 L | PV 11 input power (Low) | — | — | — | — | — | — |
-| 88 | 7 Vpv 12 | PV 12 voltage | — | — | — | — | — | — |
-| 88 | 8 PV 12 Curr | PV 12 Input current | — | — | — | — | — | — |
-| 88 | 9 Ppv 12 H | PV 12 input power (High) | — | — | — | — | — | — |
-| 89 | Input 8 total energy | PV 12 input power (Low) | — | — | — | — | tlx:input_8_energy_total | Input 8 total energy |
-| 89 | Input 8 total energy | PV 13 voltage | — | — | — | — | tlx:input_8_energy_total | Input 8 total energy |
-| 89 | Input 8 total energy | PV 13 Input current | — | — | — | — | tlx:input_8_energy_total | Input 8 total energy |
-| 89 | Input 8 total energy | PV 13 input power (High) | — | — | — | — | tlx:input_8_energy_total | Input 8 total energy |
-| 89 | Input 8 total energy | PV 13 input power (Low) | — | — | — | — | tlx:input_8_energy_total | Input 8 total energy |
-| 89 | Input 8 total energy | PV 14 voltage | — | — | — | — | tlx:input_8_energy_total | Input 8 total energy |
-| 89 | Input 8 total energy | PV 14 Input current | — | — | — | — | tlx:input_8_energy_total | Input 8 total energy |
-| 89 | Input 8 total energy | PV 14 input power (High) | — | — | — | — | tlx:input_8_energy_total | Input 8 total energy |
-| 89 | Input 8 total energy | PV 14 input power (Low) | — | — | — | — | tlx:input_8_energy_total | Input 8 total energy |
-| 89 | Input 8 total energy | PV 15 voltage | — | — | — | — | tlx:input_8_energy_total | Input 8 total energy |
-| 90 | 0 PV 15 Curr | PV 15 Input current | — | — | — | — | — | — |
-| 90 | 1 Ppv 15 H | PV 15 input power (High) | — | — | — | — | — | — |
-| 90 | 2 Ppv 15 L | PV 15 input power (Low) | — | — | — | — | — | — |
-| 90 | 3 Vpv 16 | PV 16 voltage | — | — | — | — | — | — |
-| 90 | 4 PV 16 Curr | PV 16 Input current | — | — | — | — | — | — |
-| 90 | 5 Ppv 16 H | PV 16 input power (High) | — | — | — | — | — | — |
-| 90 | 6 Ppv 16 L | PV 16 input power (Low) | — | — | — | — | — | — |
-| 90 | 7 Epv 9_today H | PV 9 energy today (High) | — | — | — | — | — | — |
-| 90 | 8 Epv 9_today L | PV 9 energy today (Low) | — | — | — | — | — | — |
-| 90 | 9 Epv 9_total H | PV 9 energy total (High) | — | — | — | — | — | — |
-| 91 | Total energy input | PV 9 energy total (Low) | — | — | — | — | tlx:input_energy_total | Total energy input |
-| 91 | Total energy input | PV 10 energy today (High) | — | — | — | — | tlx:input_energy_total | Total energy input |
-| 91 | Total energy input | PV 10 energy today (Low) | — | — | — | — | tlx:input_energy_total | Total energy input |
-| 91 | Total energy input | PV 10 energy total (High) | — | — | — | — | tlx:input_energy_total | Total energy input |
-| 91 | Total energy input | PV 10 energy total (Low) | — | — | — | — | tlx:input_energy_total | Total energy input |
-| 91 | Total energy input | PV 11 energy today (High) | — | — | — | — | tlx:input_energy_total | Total energy input |
-| 91 | Total energy input | PV 11 energy today (Low) | — | — | — | — | tlx:input_energy_total | Total energy input |
-| 91 | Total energy input | PV 11 energy total (High) | — | — | — | — | tlx:input_energy_total | Total energy input |
-| 91 | Total energy input | PV 11 energy total (Low) | — | — | — | — | tlx:input_energy_total | Total energy input |
-| 91 | Total energy input | PV 12 energy today (High) | — | — | — | — | tlx:input_energy_total | Total energy input |
-| 92 | 0 Epv 12_today L | PV 12 energy today (Low) | — | — | — | — | — | — |
-| 92 | 1 Epv 12_total H | PV 12 energy total (High) | — | — | — | — | — | — |
-| 92 | 2 Epv 12_total L | PV 12 energy total (Low) | — | — | — | — | — | — |
-| 92 | 3 Epv 13_today H | PV 13 energy today (High) | — | — | — | — | — | — |
-| 92 | 4 Epv 13_today L | PV 13 energy today (Low) | — | — | — | — | — | — |
-| 92 | 5 Epv 13_total H | PV 13 energy total (High) | — | — | — | — | — | — |
-| 92 | 6 Epv 13_total L | PV 13 energy total (Low) | — | — | — | — | — | — |
-| 92 | 7 Epv 14_today H | PV 14 energy today (High) | — | — | — | — | — | — |
-| 92 | 8 Epv 14_today L | PV 14 energy today (Low) | — | — | — | — | — | — |
-| 92 | 9 Epv 14_total H | PV 14 energy total (High) | — | — | — | — | — | — |
-| 93 | Temperature | PV 14 energy total (Low) | — | — | — | — | tlx:inverter_temperature | Temperature |
-| 93 | Temperature | PV 15 energy today (High) | — | — | — | — | tlx:inverter_temperature | Temperature |
-| 93 | Temperature | PV 15 energy today (Low) | — | — | — | — | tlx:inverter_temperature | Temperature |
-| 93 | Temperature | PV 15 energy total (High) | — | — | — | — | tlx:inverter_temperature | Temperature |
-| 93 | Temperature | PV 15 energy total (Low) | — | — | — | — | tlx:inverter_temperature | Temperature |
-| 93 | Temperature | PV 16 energy today (High) | — | — | — | — | tlx:inverter_temperature | Temperature |
-| 93 | Temperature | PV 16 energy today (Low) | — | — | — | — | tlx:inverter_temperature | Temperature |
-| 93 | Temperature | PV 16 energy total (High) | — | — | — | — | tlx:inverter_temperature | Temperature |
-| 93 | Temperature | PV 16 energy total (Low) | — | — | — | — | tlx:inverter_temperature | Temperature |
-| 93 | Temperature | PID PV 9 PE Volt/ Flyspan volta (MAX HV) | — | — | — | — | tlx:inverter_temperature | Temperature |
-| 94 | Intelligent Power Management temperature | PID PV 9 PE Current | — | — | — | — | tlx:ipm_temperature | Intelligent Power Management temperature |
-| 94 | Intelligent Power Management temperature | + PID PV 10 PE/ Flyspan voltage ( HV) | — | — | — | — | tlx:ipm_temperature | Intelligent Power Management temperature |
-| 94 | Intelligent Power Management temperature | 0+ PID PV 10 PE Current | — | — | — | — | tlx:ipm_temperature | Intelligent Power Management temperature |
-| 94 | Intelligent Power Management temperature | 1+ PID PV 11 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | tlx:ipm_temperature | Intelligent Power Management temperature |
-| 94 | Intelligent Power Management temperature | 1+ PID PV 11 PE Current | — | — | — | — | tlx:ipm_temperature | Intelligent Power Management temperature |
-| 94 | Intelligent Power Management temperature | 2+ PID PV 12 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | tlx:ipm_temperature | Intelligent Power Management temperature |
-| 94 | Intelligent Power Management temperature | 2+ PID PV 12 PE Current | — | — | — | — | tlx:ipm_temperature | Intelligent Power Management temperature |
-| 94 | Intelligent Power Management temperature | 3+ PID PV 13 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | tlx:ipm_temperature | Intelligent Power Management temperature |
-| 94 | Intelligent Power Management temperature | 3+ PID PV 13 PE Current | — | — | — | — | tlx:ipm_temperature | Intelligent Power Management temperature |
-| 94 | Intelligent Power Management temperature | 4+ PID PV 14 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | tlx:ipm_temperature | Intelligent Power Management temperature |
-| 95 | Boost temperature | 4+ PID PV 14 PE Current | — | — | — | — | tlx:boost_temperature | Boost temperature |
-| 95 | Boost temperature | 5+ PID PV 15 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | tlx:boost_temperature | Boost temperature |
-| 95 | Boost temperature | 5+ PID PV 15 PE Current | — | — | — | — | tlx:boost_temperature | Boost temperature |
-| 95 | Boost temperature | 6+ PID PV 16 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | tlx:boost_temperature | Boost temperature |
-| 95 | Boost temperature | 6+ PID PV 16 PE Current | — | — | — | — | tlx:boost_temperature | Boost temperature |
-| 95 | Boost temperature | PV String 17 voltage | — | — | — | — | tlx:boost_temperature | Boost temperature |
-| 95 | Boost temperature | PV String 17 Current | — | — | — | — | tlx:boost_temperature | Boost temperature |
-| 95 | Boost temperature | PV String 18 voltage | — | — | — | — | tlx:boost_temperature | Boost temperature |
-| 95 | Boost temperature | PV String 18 Current | — | — | — | — | tlx:boost_temperature | Boost temperature |
-| 95 | Boost temperature | PV String 19 voltage | — | — | — | — | tlx:boost_temperature | Boost temperature |
-| 96 | 0 Curr _String 19 | PV String 19 Current | — | — | — | — | — | — |
-| 96 | 1 V _String 20 | PV String 20 voltage | — | — | — | — | — | — |
-| 96 | 2 Curr _String 20 | PV String 20 Current | — | — | — | — | — | — |
-| 96 | 3 V _String 21 | PV String 21 voltage | — | — | — | — | — | — |
-| 96 | 4 Curr _String 21 | PV String 21 Current | — | — | — | — | — | — |
-| 96 | 5 V _String 22 | PV String 22 voltage | — | — | — | — | — | — |
-| 96 | 6 Curr _String 22 | PV String 22 Current | — | — | — | — | — | — |
-| 96 | 7 V _String 23 | PV String 23 voltage | — | — | — | — | — | — |
-| 96 | 8 Curr _String 23 | PV String 23 Current | — | — | — | — | — | — |
-| 96 | 9 V _String 24 | PV String 24 voltage | — | — | — | — | — | — |
-| 97 | 0 Curr _String 24 | PV String 24 Current | — | — 0.1 A | — | — | — | — |
-| 97 | 1 V _String 25 | PV String 25 voltage | — | — 0.1 V | — | — | — | — |
-| 97 | 2 Curr _String 25 | PV String 25 Current | — | — 0.1 A | — | — | — | — |
-| 97 | 3 V _String 26 | PV String 26 voltage | — | — 0.1 V | — | — | — | — |
-| 97 | 4 Curr _String 26 | PV String 26 Current | — | — 0.1 A | — | — | — | — |
-| 97 | 5 V _String 27 | PV String 27 voltage | — | — 0.1 V | — | — | — | — |
-| 97 | 6 Curr _String 27 | PV String 27 Current | — | — 0.1 A | — | — | — | — |
-| 97 | 7 V _String 28 | PV String 28 voltage | — | — 0.1 V | — | — | — | — |
-| 97 | 8 Curr _String 28 | PV String 28 Current | — | — 0.1 A | — | — | — | — |
-| 97 | 9 V _String 29 | PV String 29 voltage | — | — 0.1 V | — | — | — | — |
-| 98 | P-bus voltage | PV String 29 Current | — | — 0.1 A | — | — | tlx:p_bus_voltage | P-bus voltage |
-| 98 | P-bus voltage | PV String 30 voltage | — | — 0.1 V | — | — | tlx:p_bus_voltage | P-bus voltage |
-| 98 | P-bus voltage | PV String 30 Current | — | — 0.1 A | — | — | tlx:p_bus_voltage | P-bus voltage |
-| 98 | P-bus voltage | PV String 31 voltage | — | — 0.1 V | — | — | tlx:p_bus_voltage | P-bus voltage |
-| 98 | P-bus voltage | PV String 31 Current | — | — 0.1 A | — | — | tlx:p_bus_voltage | P-bus voltage |
-| 98 | P-bus voltage | PV String 32 voltage | — | — 0.1 V | — | — | tlx:p_bus_voltage | P-bus voltage |
-| 98 | P-bus voltage | PV String 32 Current | — | — 0.1 A | — | — | tlx:p_bus_voltage | P-bus voltage |
-| 98 | P-bus voltage | Bit 0~15: String 17~32 unmatch | — | — | — | — | tlx:p_bus_voltage | P-bus voltage |
-| 98 | P-bus voltage | Bit 0~15:String 17~32 unblance | — | — | — | — | tlx:p_bus_voltage | P-bus voltage |
-| 98 | P-bus voltage | Bit 0~15: String 17~32 disconn | — | — | — | — | tlx:p_bus_voltage | P-bus voltage |
-| 99 | N-bus voltage | PV Warning Value (PV 9-PV 16) Contains PV 9~16 abnormal, 和 Boost 9~16 Drive anomalies | — | — | — | — | tlx:n_bus_voltage | N-bus voltage |
-| 99 | N-bus voltage | string 1~string 16 abnormal | — | — | — | — | tlx:n_bus_voltage | N-bus voltage |
-| 99 | N-bus voltage | string 17~string 32 abnormal | — | — | — | — | tlx:n_bus_voltage | N-bus voltage |
-| 99 | N-bus voltage | M 3 to DSP system command | — | — system command | — | — | tlx:n_bus_voltage | N-bus voltage |
-| 10 | 00. uw Sys Work Mode | System work mode | — | — Theworkingmode displayed by the monitoring to the customer is: 0 x 00: waiting module 0 x 01: Self-test mode, 0 x 03:fault module 0 x 04:flash odule x 05|0 x 06|0 x 07|0 08:normal odule | — | — | — | — |
-| 10 | 01. Systemfault word 0 | System fault word 0 | — | — lease refer to hefault escription of ybrid | — | — | — | — |
-| 10 | 02. Systemfault word 1 | System fault word 1 | — | — | — | — | — | — |
-| 10 | 03. Systemfault word 2 | System fault word 2 | — | — | — | — | — | — |
-| 10 | 04. Systemfault word 3 | System fault word 3 | — | — | — | — | — | — |
-| 10 | 05. Systemfault word 4 | System fault word 4 | — | — | — | — | — | — |
-| 10 | 06. Systemfault word 5 | System fault word 5 | — | — | — | — | — | — |
-| 10 | 07. Systemfault word 6 | System fault word 6 | — | — | — | — | — | — |
-| 10 | 08. Systemfault word 7 | System fault word 7 | — | — | — | — | — | — |
-| 10 | 09. Pdischarge 1 H | Discharge power(high) | — | — | — | — | — | — |
-| 10 | 10. Pdischarge 1 L | Discharge power (low) | — | — | — | — | — | — |
-| 10 | 11. Pcharge 1 H | Charge power(high) | — | — | — | — | — | — |
-| 10 | 12. Pcharge 1 L | Charge power (low) | — | — | — | — | — | — |
-| 10 | 13. Vbat | Battery voltage | — | — | — | — | — | — |
-| 10 | 14. SOC | State of charge Capacity | — | — ith/leadacid | — | — | — | — |
-| 10 | 15. Pactouser R | H AC power to user H | — | — | — | — | — | — |
-| 10 | 16. Pactouser R | L AC power to user L | — | — | — | — | — | — |
-| 10 | 17. Pactouser S | H Pactouser S H | — | — | — | — | — | — |
-| 10 | 18. Pactouser S | L Pactouser S L | — | — | — | — | — | — |
-| 10 | 19. Pactouser T | H Pactouser T H | — | — | — | — | — | — |
-| 10 | 20. Pactouser T | L Pactouser T H | — | — | — | — | — | — |
-| 10 | 21. Pactouser Total H | AC power to user total H | — | — | — | — | — | — |
-| 10 | 22. Pactouser Total L | AC power to user total L | — | — | — | — | — | — |
-| 10 | 23. Pac to grid R H | AC power to grid H | — | — c output | — | — | — | — |
-| 10 | 24. Pac to grid R L | AC power to grid L | — | — | — | — | — | — |
-| 10 | 25. Pactogrid S H | — | — | — | — | — | — | — |
-| 10 | 26. Pactogrid S L | — | — | — | — | — | — | — |
-| 10 | 27. Pactogrid T H | — | — | — | — | — | — | — |
-| 10 | 28. Pactogrid T L | — | — | — | — | — | — | — |
-| 10 | 29. Pactogrid total H | AC power to grid total H | — | — | — | — | — | — |
-| 10 | 30. Pactogrid total L | AC power to grid total L | — | — | — | — | — | — |
-| 10 | 31. PLocal Load R | H INV power to local load H | — | — | — | — | — | — |
-| 10 | 32. PLocal Load R | L INV power to local load L | — | — | — | — | — | — |
-| 10 | 33. PLocal Load S | H | — | — | — | — | — | — |
-| 10 | 34. PLocal Load S | L | — | — | — | — | — | — |
-| 10 | 35. PLocal Load T H | — | — | — | — | — | — | — |
-| 10 | 36. PLocal Load T L | — | — | — | — | — | — | — |
-| 10 | 37. PLocal Load total | H INV power to local load tot | — | — | — | — | — | — |
-| 10 | 38. PLocal Load total | L INV power to local load tot L | — | — | — | — | — | — |
-| 10 | 39. IPM 2 Temperature | REC Temperature | — | — | — | — | — | — |
-| 10 | 40. Battery 2 Temperature | Battery Temperature | — | — ithium p | — | — | — | — |
-| 10 | 41. SP DSP Status | SP state | — | — | — | — | — | — |
-| 10 | 42. SP Bus Volt | SP BUS 2 Volt | — | — | — | — | — | — |
-| 10 | 43 | — | — | — | — | — | — | — |
-| 10 | 44. Etouser_today H | Energy to user today high | — | — | — | — | — | — |
-| 10 | 45. Etouser_today L | Energy to user today low | — | — | — | — | — | — |
-| 10 | 46. Etouser_total H | Energy to user total high | — | — | — | — | — | — |
-| 10 | 47. Etouser_ total L | Energy to user total high | — | — | — | — | — | — |
-| 10 | 48. Etogrid_today H | Energy to grid today high | — | — | — | — | — | — |
-| 10 | 49. Etogrid _today L | Energy to grid today low | — | — | — | — | — | — |
-| 10 | 50. Etogrid _total H | Energy to grid total high | — | — | — | — | — | — |
-| 10 | 51. Etogrid _ total L | Energy to grid total high | — | — | — | — | — | — |
-| 10 | 52. Edischarge 1_toda y H | Discharge energy 1 today | — | — | — | — | — | — |
-| 10 | 53. Edischarge 1_toda y L | Discharge energy 1 today | — | — | — | — | — | — |
-| 10 | 54. Edischarge 1_total H | Total discharge energy 1 (high) | — | — | — | — | — | — |
-| 10 | 55. Edischarge 1_total L | Total discharge energy 1 (low) | — | — | — | — | — | — |
-| 10 | 56. Echarge 1_today H | Charge 1 energy today | — | — | — | — | — | — |
-| 10 | 57. Echarge 1_today L | Charge 1 energy today | — | — | — | — | — | — |
-| 10 | 58. Echarge 1_total H | Charge 1 energy total | — | — | — | — | — | — |
-| 10 | 59. Echarge 1_total L | Charge 1 energy total | — | — | — | — | — | — |
-| 10 | 60. ELocal Load_Today H | Local load energy today | — | — | — | — | — | — |
-| 10 | 61. ELocal Load_Today L | Local load energy today | — | — | — | — | — | — |
-| 10 | 62. ELocal Load_Total H | Local load energy total | — | — | — | — | — | — |
-| 10 | 63. ELocal Load_Total L | Local load energy total | — | — | — | — | — | — |
-| 10 | 64. dw Export Limit Ap parent Power | Export Limit Apparent Power H | — | — rent Power | — | — | — | — |
-| 10 | 65. dw Export Limit Ap parent Power | Export Limit Apparent Power L | — | — rent Power | — | — | — | — |
-| 10 | 66. / | / | — | — rved | — | — | — | — |
-| 10 | 67. EPS Fac | UPSfrequency | — | — | — | — | — | — |
-| 10 | 68. EPS Vac 1 | UPS phase R output voltage | — | — | — | — | — | — |
-| 10 | 69. EPS Iac 1 | UPS phase R output current | — | — | — | — | — | — |
-| 10 | 70. EPS Pac 1 H | UPS phase R output power (H) | — | — | — | — | — | — |
-| 10 | 71. EPS Pac 1 L | UPS phase R output power (L) | — | — | — | — | — | — |
-| 10 | 72. EPS Vac 2 | UPS phase S output voltage | — | — | — | — | — | — |
-| 10 | 73. EPS Iac 2 | UPS phase S output current | — | — se | — | — | — | — |
-| 10 | 74. EPS Pac 2 H | UPS phase S output power (H) | — | — | — | — | — | — |
-| 10 | 75. EPS Pac 2 L | UPS phase S output power (L) | — | — | — | — | — | — |
-| 10 | 76. EPS Vac 3 | UPS phase T output voltage | — | — | — | — | — | — |
-| 10 | 77. EPS Iac 3 | UPS phase T output current | — | — se | — | — | — | — |
-| 10 | 78. EPS Pac 3 H | UPS phase T output power (H) | — | — | — | — | — | — |
-| 10 | 79. EPS Pac 3 L | UPS phase T output power (L) | — | — | — | — | — | — |
-| 10 | 80. Loadpercent | Load percent of UPS ouput | — | — | — | — | — | — |
-| 10 | 81. PF | Power factor | — | — ary Value+1 | — | — | — | — |
-| 10 | 82. BMS_Status Old | Status Old from BMS | — | — | — | — | — | — |
-| 10 | 83. BMS_Status | Status from BMS | — | — | — | — | — | — |
-| 10 | 84. BMS_Error Old | Error info Old from BMS | — | — | — | — | — | — |
-| 10 | 85. BMS_Error | Errorinfomation from BMS | — | — | — | — | — | — |
-| 10 | 86. BMS_SOC BMS_Battery Vol | SOC from BMS Battery voltage from BMS | — | — H 6 K H 6 K | — | — | — | — |
-| 10 | 87. t BMS_Battery Cur | Battery current from BMS | — | — | — | — | — | — |
-| 10 | 88. r BMS_Battery Te | Battery temperature from BMS | — | — | — | — | — | — |
-| 10 | 89. mp BMS_Max Curr | Max. charge/discharge current | — | — | — | — | — | — |
-| 10 | 90. | from BMS (pylon) | — | — | — | — | — | — |
-| 10 | 91. BMS_Gauge RM | Gauge RM from BMS | — | — | — | — | — | — |
-| 10 | 92. BMS_Gauge FCC | Gauge FCC from BMS | — | — | — | — | — | — |
-| 10 | 93. BMS_FW | — | — | — | — | — | — | — |
-| 10 | 94. BMS_Delta Volt | Delta V from BMS | — | — | — | — | — | — |
-| 10 | 95. BMS_Cycle Cnt | Cycle Count from BMS | — | — | — | — | — | — |
-| 10 | 96. BMS_SOH BMS_Constant V | SOH from BMS CV voltage from BMS | — | — | — | — | — | — |
-| 10 | 97. olt BMS_Warn Info O | Warning info old from BMS | — | — | — | — | — | — |
-| 10 | 98. ld | — | — | — | — | — | — | — |
-| 10 | 99. BMS_Warn Info BMS_Gauge ICCu | Warning info from BMS Gauge IC current from BMS | — | — | — | — | — | — |
-| 11 | Input 3 voltage | MCU Software version from BMS | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Gauge Version from BMS | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Gauge FR Version L 16 from BMS | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Gauge FR Version H 16 from BMS | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | — | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | BMSInformation from BMS | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Pack Information from BMS | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Using Cap from BMS | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Maximum single battery voltage | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Lowest single battery voltage | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Battery parallel number | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Number of batteries Max Volt Cell No | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Min Volt Cell No | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Max Tempr Cell_10 T | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Min Tempr Cell_10 T | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Max Volt Tempr Cell No | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | — | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Min Volt Tempr Cell No | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Faulty Battery Address | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Parallel maximum SOC | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Parallel minimum SOC Battery Protection 2 | — | — CAN ID: 0 x 323 | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Battery Protection 3 | — | — Byte 4~5 CAN ID: 0 x 323 | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Battery Warn 2 | — | — Byte 6 CAN ID: 0 x 323 | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | — | — | — Byte 7 | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | AC Charge Energy today | — | — Energy today | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | AC Charge Energy today | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | — | — | — Energy total | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | — | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | AC Charge Power | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | AC Charge Power | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | uw Grid Power_70_Adj EE_SP | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | tra inverte AC Power to grid gh | — | — SPA used | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | trainverte AC Power to grid Low | — | — SPA used | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Extra inverter Power TOUser_Extr today (high) | — | — SPA used | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Extra inverter Power TOUser_Extr today (low) | — | — SPA used | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Extra inverter Power TOUser_Extr total(high) | — | — SPA used | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Extra inverter Power TOUser_Extr total(low) | — | — SPA used | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | System electric energy today H | — | — SPA used System electric energy today H | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | stem electric energy today L | — | — d electric today L | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | System electric energy total H | — | — d electric total H | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | System electric energy total L | — | — d electric total L | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | self electric energy today H | — | — electric today H | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | self electric energy today L | — | — electric today L | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | self electric energy total H | — | — electric total H | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | self electric energy total L | — | — electric total L | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | System power H | — | — power H | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | System power L | — | — power L | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | self power H | — | — wer H | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | self power L | — | — wer L | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | PV electric energy today H | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | PV electric energy today L | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Discharge power pack number | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Cumulative discharge power high 16-bit byte | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Cumulative discharge power low 16-bit byte | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | charge power pack serial number | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Cumulative charge power high R 16-bit byte | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Cumulative charge power low R 16-bit byte | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | First Batt Fault Sn | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Second Batt Fault Sn | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Third Batt Fault Sn | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Fourth Batt Fault Sn | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Battery history fault code 1 | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Battery history fault code 2 | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Battery history fault code 3 | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Battery history fault code 4 | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Battery history fault code 5 | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Battery history fault code 6 | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Battery history fault code 7 | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Battery history fault code 8 | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Number of battery codes PACK number + BIC forward and reverse codes | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | — | — | — | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 11 | Input 3 voltage | Intelligent reading is used to identify software compatibility features | — | — rgy; rgy | — | — | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
-| 1 | Input 1 voltage | Maximum cell voltage | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Minimum cell voltage | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Number of Battery modules | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Total number of cells | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Max Volt Cell No | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Min Volt Cell No | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Max Tempr Cell_10 T | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Min Tempr Cell_10 T | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Max Tempr Cell No | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Min Tempr Cell No | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Fault Pack ID | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Parallel maximum SOC | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Parallel minimum SOC | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Bat Protect 1 Add | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Bat Protect 2 Add | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | Bat Warn 1 Add | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | BMS_Highest Soft Version | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | BMS_Hardware Version | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 1 | Input 1 voltage | BMS_Request Type | — | — | — | — | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
-| 12 | Input 3 Amperage | Success sign of key detection before aging | — | — 1:Finished test 0: test not completed | — | — | tlx:input_3_amperage | Input 3 Amperage |
-| 12 | Input 3 Amperage | / | — | — reversed | — | — | tlx:input_3_amperage | Input 3 Amperage |
-| 20 | Grid voltage | Inverter run state | — | — SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Output power (high) | — | — 1 W SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Output power (low) | — | — 1 W SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Grid frequency | — | — 01 Hz SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Three/single phase grid voltage | — | — 1 V SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Three/single phase grid output | — | — 1 A SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Three/single phase grid output VA (high) | — | — 1 VA SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Three/single phase grid output VA(low) | — | — 1 VA SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Today generate energy (high) | — | — 1 k WH SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Today generate energy (low) | — | — 1 k WH SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Total generate energy (high) | — | — WH SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Total generate energy (low) | — | — WH SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Work time total (high) | — | — SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Work time total (low) | — | — SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Inverter temperature | — | — SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | The inside IPM in inverter Temp | — | — SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Boost temperature | — | — SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | — | — | — reserved | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | Bat Volt_DSP | — | — Bat Volt(DSP) | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | P Bus inside Voltage | — | — SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 20 | Grid voltage | N Bus inside Voltage | — | — SPA | — | — | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
-| 21 | AC frequency | / | — | — Remote setup enable | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | / | — | — Remotely set power | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | Extra inverte AC Power to grid | — | — SPA used | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | Extrainverte AC Power to grid L | — | — SPA used | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | Extra inverter Power TOUser_Extr today (high) | — | — Wh SPA used | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | Extra inverter Power TOUser_Extr today (low) | — | — Wh SPA used | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | Extra inverter Power TOUser_Extratotal(high) | — | — Wh SPA used | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | Extra inverter Power TOUser_Extr total(low) | — | — Wh SPA used | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | System electric energy today H | — | — Wh SPA used System electric energy today H | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | stem electric energy today L | — | — Wh SPA used System electric energy today L | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | System electric energy total H | — | — Wh SPA used System c total | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | System electric energy total L | — | — d c total | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | ACCharge energy today | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | ACCharge energy today | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | ACCharge energy total | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | ACCharge energy total | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | Grid power to local load | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | Grid power to local load | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | 0:Load First 1:Battery First 2:Grid First | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | 0:Lead-acid 1:Lithium battery | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | Aging mode | — | — | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 21 | AC frequency | — | — | — d | — | — | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
-| 3 | Input 1 Wattage | 2: Reserved 3:Sys Fault module 4: Flash module 5:PVBATOnline module: 6:Bat Online module 7:PVOffline Mode 8:Bat Offline Mode The lower 8 bits indicate the m status (web page display) 0: Standby Status; 1: Normal Status; 3: Fault Status 4:Flash Status; | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV total power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 1 voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 1 input current | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 1 power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 2 voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 2 input current | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 2 power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 3 voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 3 input current | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 3 power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 4 voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 4 input current | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 4 power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | System output power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | reactive power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Output power | — | — ut | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Grid frequency | — | — r | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three/single phase grid voltage | — | — uency e/single | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — e grid age | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three/single phase grid output | — | — e/single rid | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three/single phase grid output VA | — | — ingle rid | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three phase grid voltage | — | — watt hase | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three phase grid output current | — | — ltage hase | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — tput | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three phase grid output power | — | — hase tput | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three phase grid voltage | — | — hase | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three phase grid output current | — | — ltage hase | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — tput | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three phase grid output power | — | — hase tput | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three phase grid voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three phase grid voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Three phase grid voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total forward power | — | — orward | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total reverse power | — | — everse | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total load power | — | — load | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Work time total | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Today generate energy | — | — e | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total generate energy | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — e | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV energy total | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 1 energy today | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 1 energy total | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 2 energy today | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 2 energy total | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 3 energy today | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 3 energy total | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Today energy to user | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total energy to user | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Today energy to grid | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total energy to grid | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Today energy of user load | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total energy of user load | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 4 energy today | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV 4 energy total | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV energy today | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Derating Mode | — | — h | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — k T l A i | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | PV ISO value | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | R DCI Curr | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | S DCI Curr | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | T DCI Curr | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | GFCI Curr | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | total bus voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Inverter temperature | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | The inside IPM in inverter temp | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Boost temperature | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Reserved | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Commmunication broad temperatur | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | P Bus inside Voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | N Bus inside Voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Inverter output PF now | — | — 000 | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Real Output power Percent | — | — 0 | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Output Maxpower Limited | — | — ut ower | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Inverter standby flag | — | — ted:turn off r;:PV Low;:AC | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — /Freq of scope; ~bit 7: rved | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Inverter fault maincode | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Inverter Warning maincode | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Inverter fault subcode | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Inverter Warning subcode | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Present FFTValue [CHANNEL_A] | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | AFCI Status | — | — waiting e lf-check Detection | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | AFCI Strength[CHANNEL_A] | — | — arcing e ult state update e | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | AFCI Self Check[CHANNEL_A] | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | inv start delay time | — | — lay | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BDC connect state | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Current status of Dry Contact | — | — of | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | self-use power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | System energy today | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Today discharge energy | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total discharge energy | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Charge energy today | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Charge energy total | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Today energy of AC charge | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total energy of AC charge | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total energy of system outpu | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Today energy of Self output | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total energy of Self output | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Word Mode | — | — ad First | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — ery Firs id First | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | UPS frequency | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | UPS phase R output voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | UPS phase R output current | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | UPS phase R output power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | UPS phase S output voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | UPS phase S output current | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | UPS phase S output power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | UPS phase T output voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | UPS phase T output current | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | UPS phase T output power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | UPS output power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Load percent of UPS ouput | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Power factor | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | DC voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Whether to parse BDC data separ | — | — on't need | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BDCDerating Mode: 0: Normal, unrestricted 1:Standby or fault | — | — ed | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | 2:Maximum battery current limit (discharge) 3:Battery discharge Enable (Dis 4:High bus discharge derating (discharge) 5:High temperature discharge derating (discharge) 6:System warning No discharge (discharge) 7-15 Reserved (Discharge) 16:Maximum charging current of battery (charging) 17:High Temperature (LLC and Buckboost) (Charging) 18:Final soft charge 19:SOC setting limits (charging 20:Battery low temperature (cha 21:High bus voltage (charging) 22:Battery SOC (charging) 23: Need to charge (charge) 24: System warning not charging (charging) 25-29:Reserve (charge) System work State and mode The upper 8 bits indicate the mode; 0:No charge and discharge; 1:charge; 2:Discharge; | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | The lower 8 bits represent the 0: Standby Status; 1: Normal Status; 2: Fault Status 3:Flash Status; | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Storge device fault code | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Storge device warning code | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Battery voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Battery current | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | State of charge Capacity | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Total BUS voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | On the BUS voltage | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BUCK-BOOST Current | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | LLC Current | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Temperture A | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Temperture B | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Discharge power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Charge power | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Discharge total energy of storg | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Charge total energy of storge d | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Reserved BDC mark (charge and dischar fault alarm code) Bit 0: Charge En; BDC allows char Bit 1: Discharge En; BDC allows discharge | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bit 2~7: Resvd; reserved Bit 8~11: Warn Sub Code; BDC sub-warning code Bit 12~15: Fault Sub Code; BDC sub-error code | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Lower BUS voltage Bms Max Volt Cell No | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bms Min Volt Cell No | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bms Battery Avg Temp | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bms Max Cell Temp | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bms Battery Avg Temp | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bms Max Cell Temp | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bms Battery Avg Temp | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bms Max SOC | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bms Min SOC Parallel Battery Num | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bms Derate Reason | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bms Gauge FCC(Ah) | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Bms Gauge RM(Ah) | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMS Protect 1 | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMSWarn 1 | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMS Fault 1 | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMS Fault 2 | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Battery ISO detection status | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | battery work request | — | — n | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | battery working status | — | — mancy ge harge | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — dby start t te | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMS Protect 2 | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMS Warn 2 | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMS SOC BMS Battery Volt | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMS Battery Curr | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | battery cell maximum temperatur | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Maximum charging current Maximum discharge current | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMSCycle Cnt | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMS SOH Battery charging voltage limit | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | Battery discharge voltage limit | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMS Warn 3 | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | BMS Protect 3 | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 3 | Input 1 Wattage | — | — | — | — | — | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
-| 32 | Input 8 Amperage | — | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | BMS Battery Single Volt Max | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | BMS Battery Single Volt Min | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Battery Load Volt | — | — 0,650.00] | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | — | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 1 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 2 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 3 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 4 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 5 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 6 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 7 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 8 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 9 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 10 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 10 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 12 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 13 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 14 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 15 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Debug data 16 | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 1 output power H | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 1 output power L | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 2 output power H | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 2 output power L | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 1 energy Today H | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 1 energy Today L | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 2 energy Today H | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 2 energy Today L | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 1 energy Total H | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 1 energy Total L | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 2 energy Total H | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | PV inverter 2 energy Total L | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | battery pack number | — | — C reports e updated ery 15 nutes | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Battery pack serial number SN[0] | — | — C reports e updated | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Battery pack serial number SN[2] | — | — ery 15 | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Battery pack serial number SN[4] | — | — nutes | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Battery pack serial number SN[6] | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Battery pack serial number SN[8] | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Battery pack serial number SN[10]SN[11] | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Battery pack serial number SN[12]SN[13] | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Battery pack serial number SN[14]SN[15] | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Reserve | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | — | — | — | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 32 | Input 8 Amperage | Clear day data flag | — | — ta of the rrent day at the rver determines whether to clear. 0:not cleared. 1: Clear. | — | — | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
-| 40 | Fault code | The first 8 registers are the 1 | — | — en 69 registers have the | — | — | tlx:output_1_power, tl3:fault_code | Fault code, Output 1 Wattage |
-| 41 | Intelligent Power Management temperature | same data area as 3165-3233, th 108 registers (including 8 regi | — | — eserved, a total of r). | — | — | tl3:ipm_temperature | Intelligent Power Management temperature |
-| 41 | Intelligent Power Management temperature | The first 8 registers are the 1 | — | — en 69 registers have the | — | — | tl3:ipm_temperature | Intelligent Power Management temperature |
-| 42 | Fault code | same data area as 3165-3233, th 108 registers (including 8 regi | — | — eserved, a total of r). | — | — | tlx:output_2_voltage, tl3:p_bus_voltage, offgrid:fault_code | Fault code, Output 2 voltage, P-bus voltage |
-| 48 | Input 1 energy today | The first 8 registers are the 1 | — | — en 69 registers have the | — | — | tlx:output_3_power, tl3:input_1_energy_today, offgrid:input_1_energy_today | Input 1 energy today, Output 3 Wattage, PV1 energy produced today |
-| 49 | 71 | same data area as 3165-3233, th 108 registers (including 8 regi | — | — eserved, a total of r). | — | — | — | — |
-| 49 | 72- 10 | The first 8 registers are the 1 | — | — en 69 registers have the | — | — | — | — |
-| 50 | Input 1 total energy | same data area as 3165-3233, th 108 registers (including 8 regi | — | — eserved, a total of r). | — | — | tl3:input_1_energy_total, offgrid:input_1_energy_total | Input 1 total energy, PV1 energy produced Lifetime |
+| 0 | Inverter status | Operating state reported by the inverter controller (0=waiting, 1=normal, 3=fault, 5=PV charge, 6=AC charge, 7=combined charge, 8=combined charge bypass, 9=PV charge bypass, 10=AC charge bypass, 11=bypass, 12=PV charge + discharge). | R | — | — | inverter_status_code | tlx:status_code, tl3:status_code, offgrid:status_code | Status code |
+| 1 | PV input power | Total PV input power summed across all strings (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | tlx:input_power, tl3:input_power, offgrid:input_1_voltage | Input 1 voltage, Internal wattage, PV1 voltage |
+| 3 | PV 1 DC voltage | Instantaneous PV 1 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_1_voltage, tl3:input_1_voltage, offgrid:input_1_power | Input 1 Wattage, Input 1 voltage, PV1 charge power, PV1 voltage |
+| 4 | PV 1 DC current | Instantaneous PV 1 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_1_amperage, tl3:input_1_amperage | Input 1 Amperage, PV1 buck current |
+| 5 | PV 1 DC power | Real-time DC power from PV 1 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_1_power, tl3:input_1_power, offgrid:input_2_power | Input 1 Wattage, Input 2 Wattage, PV1 charge power, PV2 charge power |
+| 7 | PV 2 DC voltage | Instantaneous PV 2 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_2_voltage, tl3:input_2_voltage, offgrid:input_1_amperage | Input 1 Amperage, Input 2 voltage, PV1 buck current, PV2 voltage |
+| 8 | PV 2 DC current | Instantaneous PV 2 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_2_amperage, tl3:input_2_amperage, offgrid:input_2_amperage | Input 2 Amperage, PV2 buck current |
+| 9 | PV 2 DC power | Real-time DC power from PV 2 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_2_power, tl3:input_2_power, offgrid:output_active_power | Input 2 Wattage, Output active power, PV2 charge power |
+| 11 | PV 3 DC voltage | Instantaneous PV 3 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_3_voltage, tl3:output_power | Input 3 voltage, Output power |
+| 12 | PV 3 DC current | Instantaneous PV 3 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_3_amperage | Input 3 Amperage |
+| 13 | PV 3 DC power | Real-time DC power from PV 3 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_3_power, tl3:grid_frequency, offgrid:charge_power | AC frequency, Battery charge power, Charge Power, Grid frequency, Input 3 Wattage |
+| 15 | PV 4 DC voltage | Instantaneous PV 4 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_4_voltage, tl3:output_1_amperage | Input 4 voltage, Output 1 Amperage, Output amperage |
+| 16 | PV 4 DC current | Instantaneous PV 4 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_4_amperage, tl3:output_1_power | Input 4 Amperage, Output 1 Wattage |
+| 17 | PV 4 DC power | Real-time DC power from PV 4 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_4_power, offgrid:battery_voltage | Battery voltage, Input 4 Wattage |
+| 19 | PV 5 DC voltage | Instantaneous PV 5 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_5_voltage, tl3:output_2_amperage, offgrid:bus_voltage | Bus voltage, Input 5 voltage, Output 2 Amperage |
+| 20 | PV 5 DC current | Instantaneous PV 5 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_5_amperage, tl3:output_2_power, offgrid:grid_voltage | Grid voltage, Input 5 Amperage, Output 2 Wattage |
+| 21 | PV 5 DC power | Real-time DC power from PV 5 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_5_power, offgrid:grid_frequency | AC frequency, Grid frequency, Input 5 Wattage |
+| 23 | PV 6 DC voltage | Instantaneous PV 6 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_6_voltage, tl3:output_3_amperage, offgrid:output_frequency | Input 6 voltage, Output 3 Amperage, Output frequency |
+| 24 | PV 6 DC current | Instantaneous PV 6 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_6_amperage, tl3:output_3_power, offgrid:output_dc_voltage | Input 6 Amperage, Output 3 Wattage, Output DC voltage |
+| 25 | PV 6 DC power | Real-time DC power from PV 6 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_6_power, offgrid:inverter_temperature | Input 6 Wattage, Temperature |
+| 27 | PV 7 DC voltage | Instantaneous PV 7 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_7_voltage, offgrid:load_percent | Input 7 voltage, Inverter load |
+| 28 | PV 7 DC current | Instantaneous PV 7 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_7_amperage, tl3:output_energy_total, offgrid:battery_port_voltage | Battery port voltage, Input 7 Amperage, Total energy produced |
+| 29 | PV 7 DC power | Real-time DC power from PV 7 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_7_power, offgrid:battery_bus_voltage | Battery bus voltage, Input 7 Wattage |
+| 31 | PV 8 DC voltage | Instantaneous PV 8 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_8_voltage | Input 8 voltage |
+| 32 | PV 8 DC current | Instantaneous PV 8 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_8_amperage, tl3:inverter_temperature | Input 8 Amperage, Temperature |
+| 33 | PV 8 DC power | Real-time DC power from PV 8 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_8_power | Input 8 Wattage |
+| 35 | AC output power | Active AC output power delivered by the inverter (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | tlx:output_power | Output power |
+| 37 | Grid frequency | Measured grid frequency with 0.01 Hz resolution. | R | — Hz | — | u 16_frequency_centihz | tlx:grid_frequency | AC frequency, Grid frequency |
+| 38 | AC phase L 1 voltage | AC output voltage for phase L 1. | R | — V | — | u 16_voltage_decivolt | tlx:output_1_voltage | Output 1 voltage, Output voltage |
+| 39 | AC phase L 1 current | AC output current for phase L 1. | R | — A | — | u 16_current_deciamp | tlx:output_1_amperage | Output 1 Amperage, Output amperage |
+| 40 | AC phase L 1 power | Active power exported on phase L 1. | R | — W | — | u 32_power_w_decawatt | tlx:output_1_power, tl3:fault_code | Fault code, Output 1 Wattage |
+| 42 | AC phase L 2 voltage | AC output voltage for phase L 2. | R | — V | — | u 16_voltage_decivolt | tlx:output_2_voltage, tl3:p_bus_voltage, offgrid:fault_code | Fault code, Output 2 voltage, P-bus voltage |
+| 43 | AC phase L 2 current | AC output current for phase L 2. | R | — A | — | u 16_current_deciamp | tlx:output_2_amperage, tl3:n_bus_voltage, offgrid:warning_code | N-bus voltage, Output 2 Amperage, Warning code |
+| 44 | AC phase L 2 power | Active power exported on phase L 2. | R | — W | — | u 32_power_w_decawatt | tlx:output_2_power | Output 2 Wattage |
+| 46 | AC phase L 3 voltage | AC output voltage for phase L 3. | R | — V | — | u 16_voltage_decivolt | tlx:output_3_voltage | Output 3 voltage |
+| 47 | AC phase L 3 current | AC output current for phase L 3. | R | — A | — | u 16_current_deciamp | tlx:output_3_amperage, tl3:derating_mode, offgrid:constant_power | Derating mode, Output 3 Amperage |
+| 48 | AC phase L 3 power | Active power exported on phase L 3. | R | — W | — | u 32_power_w_decawatt | tlx:output_3_power, tl3:input_1_energy_today, offgrid:input_1_energy_today | Input 1 energy today, Output 3 Wattage, PV1 energy produced today |
+| 53 | Output energy today | Energy exported to the AC output today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:output_energy_today | Energy produced today |
+| 55 | Output energy total | Lifetime AC output energy (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:output_energy_total | Total energy produced |
+| 57 | Run time | Total cumulative run time of the inverter. Raw values are seconds scaled by 1/7200 (0.0001389 hours). | R | — h | — | u 32_runtime_hours; Raw counter counts seconds; divide by 7200 to obtain hours. | tlx:operation_hours | Running hours |
+| 59 | PV 1 energy today | Energy harvested by PV 1 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_1_energy_today | Input 1 energy today, PV1 energy produced today |
+| 61 | PV 1 energy total | Lifetime energy harvested by PV 1. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_1_energy_total | Input 1 total energy, PV1 energy produced Lifetime |
+| 63 | PV 2 energy today | Energy harvested by PV 2 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_2_energy_today | Input 2 energy today, PV2 energy produced today |
+| 65 | PV 2 energy total | Lifetime energy harvested by PV 2. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_2_energy_total, tl3:warning_value | Input 2 total energy, PV2 energy produced Lifetime |
+| 67 | PV 3 energy today | Energy harvested by PV 3 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_3_energy_today | Input 3 energy today |
+| 69 | PV 3 energy total | Lifetime energy harvested by PV 3. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_3_energy_total, offgrid:discharge_power | Battery discharge power, Discharge Power, Input 3 total energy |
+| 71 | PV 4 energy today | Energy harvested by PV 4 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_4_energy_today | Input 4 energy today |
+| 73 | PV 4 energy total | Lifetime energy harvested by PV 4. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_4_energy_total, offgrid:battery_discharge_amperage | Battery discharge current, Input 4 total energy |
+| 75 | PV 5 energy today | Energy harvested by PV 5 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_5_energy_today | Input 5 energy today |
+| 77 | PV 5 energy total | Lifetime energy harvested by PV 5. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_5_energy_total, offgrid:battery_power | Battery charging/ discharging(-ve), Input 5 total energy |
+| 79 | PV 6 energy today | Energy harvested by PV 6 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_6_energy_today | Input 6 energy today |
+| 81 | PV 6 energy total | Lifetime energy harvested by PV 6. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_6_energy_total | Input 6 total energy |
+| 83 | PV 7 energy today | Energy harvested by PV 7 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_7_energy_today | Input 7 energy today |
+| 85 | PV 7 energy total | Lifetime energy harvested by PV 7. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_7_energy_total | Input 7 total energy |
+| 87 | PV 8 energy today | Energy harvested by PV 8 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_8_energy_today | Input 8 energy today |
+| 89 | PV 8 energy total | Lifetime energy harvested by PV 8. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_8_energy_total | Input 8 total energy |
+| 91 | PV energy total | Total PV energy generated across all strings (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_energy_total | Total energy input |
+| 93 | Inverter temperature | Main inverter heatsink temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:inverter_temperature | Temperature |
+| 94 | IPM temperature | IPM (power module) temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:ipm_temperature | Intelligent Power Management temperature |
+| 95 | Boost temperature | Boost inductor temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:boost_temperature | Boost temperature |
+| 98 | P-bus voltage | Positive DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | tlx:p_bus_voltage | P-bus voltage |
+| 99 | N-bus voltage | Negative DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | tlx:n_bus_voltage | N-bus voltage |
+| 101 | Output power percentage | Instantaneous AC output as a percentage of the inverter's rated power. | R | — % | — | u 16_percent | tlx:real_output_power_percent | Real power output percentage |
+| 104 | Derating mode | Active derating reason reported by the inverter controller. | R | — | — | u 16_raw_code | tlx:derating_mode | Derating mode |
+| 105 | Fault code | Current inverter fault code (see protocol documentation). | R | — | — | u 16_status_word | tlx:fault_code | Fault code |
+| 110 | Warning code | Current inverter warning code (vendor-defined bitmask). | R | — | — | u 16_status_word | tlx:warning_code | Warning code |
+
+## TL-X/TL-XH Input Registers (3000–3124)
+Primary TL-X/TL-XH telemetry mirror (PV/AC metrics).
+
+**Applies to:** TL-X/TL-XH/TL-XH US
+
+| Register | Name | Description | Access | Range/Unit | Initial | Notes | Attributes | Sensors |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 3000 | Inverter status | Operating state reported by the inverter controller (0=waiting, 1=normal, 3=fault, 5=PV charge, 6=AC charge, 7=combined charge, 8=combined charge bypass, 9=PV charge bypass, 10=AC charge bypass, 11=bypass, 12=PV charge + discharge). | R | — | — | inverter_status_code | tlx:status_code | Status code |
+| 3001 | PV input power | Total PV input power summed across all strings (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | tlx:input_power | Internal wattage |
+| 3003 | PV 1 DC voltage | Instantaneous PV 1 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_1_voltage | Input 1 voltage, PV1 voltage |
+| 3004 | PV 1 DC current | Instantaneous PV 1 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_1_amperage | Input 1 Amperage, PV1 buck current |
+| 3005 | PV 1 DC power | Real-time DC power from PV 1 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_1_power | Input 1 Wattage, PV1 charge power |
+| 3007 | PV 2 DC voltage | Instantaneous PV 2 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_2_voltage | Input 2 voltage, PV2 voltage |
+| 3008 | PV 2 DC current | Instantaneous PV 2 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_2_amperage | Input 2 Amperage, PV2 buck current |
+| 3009 | PV 2 DC power | Real-time DC power from PV 2 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_2_power | Input 2 Wattage, PV2 charge power |
+| 3011 | PV 3 DC voltage | Instantaneous PV 3 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_3_voltage | Input 3 voltage |
+| 3012 | PV 3 DC current | Instantaneous PV 3 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_3_amperage | Input 3 Amperage |
+| 3013 | PV 3 DC power | Real-time DC power from PV 3 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_3_power | Input 3 Wattage |
+| 3015 | PV 4 DC voltage | Instantaneous PV 4 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_4_voltage | Input 4 voltage |
+| 3016 | PV 4 DC current | Instantaneous PV 4 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_4_amperage | Input 4 Amperage |
+| 3017 | PV 4 DC power | Real-time DC power from PV 4 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_4_power | Input 4 Wattage |
+| 3021 | Output reactive power | Instantaneous reactive power on the AC output (positive = inductive, negative = capacitive). | R | — var | — | s 32_reactive_power_decivar | tlx:output_reactive_power | Reactive wattage |
+| 3023 | AC output power | Active AC output power delivered by the inverter (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | tlx:output_power | Output power |
+| 3025 | Grid frequency | Measured grid frequency with 0.01 Hz resolution. | R | — Hz | — | u 16_frequency_centihz | tlx:grid_frequency | AC frequency, Grid frequency |
+| 3026 | AC phase L 1 voltage | AC output voltage for phase L 1. | R | — V | — | u 16_voltage_decivolt | tlx:output_1_voltage | Output 1 voltage, Output voltage |
+| 3027 | AC phase L 1 current | AC output current for phase L 1. | R | — A | — | u 16_current_deciamp | tlx:output_1_amperage | Output 1 Amperage, Output amperage |
+| 3028 | AC phase L 1 power | Active power exported on phase L 1. | R | — W | — | u 32_power_w_decawatt | tlx:output_1_power | Output 1 Wattage |
+| 3030 | AC phase L 2 voltage | AC output voltage for phase L 2. | R | — V | — | u 16_voltage_decivolt | tlx:output_2_voltage | Output 2 voltage |
+| 3031 | AC phase L 2 current | AC output current for phase L 2. | R | — A | — | u 16_current_deciamp | tlx:output_2_amperage | Output 2 Amperage |
+| 3032 | AC phase L 2 power | Active power exported on phase L 2. | R | — W | — | u 32_power_w_decawatt | tlx:output_2_power | Output 2 Wattage |
+| 3034 | AC phase L 3 voltage | AC output voltage for phase L 3. | R | — V | — | u 16_voltage_decivolt | tlx:output_3_voltage | Output 3 voltage |
+| 3035 | AC phase L 3 current | AC output current for phase L 3. | R | — A | — | u 16_current_deciamp | tlx:output_3_amperage | Output 3 Amperage |
+| 3036 | AC phase L 3 power | Active power exported on phase L 3. | R | — W | — | u 32_power_w_decawatt | tlx:output_3_power | Output 3 Wattage |
+| 3041 | Load supply power | Real-time active power delivered to on-site (self-consumption) loads. | R | — W | — | u 32_power_w_decawatt | tlx:power_to_user | Power to user |
+| 3043 | Grid export power | Active power exported to the utility grid. | R | — W | — | u 32_power_w_decawatt | tlx:power_to_grid | Power to grid |
+| 3045 | Home load power | Aggregate instantaneous demand from on-site loads. | R | — W | — | u 32_power_w_decawatt | tlx:power_user_load | Power user load |
+| 3047 | Run time | Total cumulative run time of the inverter. Raw values are seconds scaled by 1/7200 (0.0001389 hours). | R | — h | — | u 32_runtime_hours; Raw counter counts seconds; divide by 7200 to obtain hours. | tlx:operation_hours | Running hours |
+| 3049 | Output energy today | Energy exported to the AC output today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:output_energy_today | Energy produced today |
+| 3051 | Output energy total | Lifetime AC output energy (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:output_energy_total | Total energy produced |
+| 3053 | PV energy total | Total PV energy generated across all strings (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_energy_total | Total energy input |
+| 3055 | PV 1 energy today | Energy harvested by PV 1 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_1_energy_today | Input 1 energy today, PV1 energy produced today |
+| 3057 | PV 1 energy total | Lifetime energy harvested by PV 1. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_1_energy_total | Input 1 total energy, PV1 energy produced Lifetime |
+| 3059 | PV 2 energy today | Energy harvested by PV 2 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_2_energy_today | Input 2 energy today, PV2 energy produced today |
+| 3061 | PV 2 energy total | Lifetime energy harvested by PV 2. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_2_energy_total | Input 2 total energy, PV2 energy produced Lifetime |
+| 3063 | PV 3 energy today | Energy harvested by PV 3 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_3_energy_today | Input 3 energy today |
+| 3065 | PV 3 energy total | Lifetime energy harvested by PV 3. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:input_3_energy_total | Input 3 total energy |
+| 3067 | Load energy today | Energy delivered to on-site loads today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:energy_to_user_today | Energy To User (Today) |
+| 3069 | Load energy total | Lifetime energy delivered to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:energy_to_user_total | Energy To User (Total) |
+| 3071 | Export energy today | Energy exported to the grid today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:energy_to_grid_today | Energy To Grid (Today) |
+| 3073 | Export energy total | Lifetime energy exported to the grid (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:energy_to_grid_total | Energy To Grid (Total) |
+| 3086 | Derating mode | Active derating reason reported by the inverter controller. | R | — | — | u 16_raw_code | tlx:derating_mode | Derating mode |
+| 3093 | Inverter temperature | Main inverter heatsink temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:inverter_temperature | Temperature |
+| 3094 | IPM temperature | IPM (power module) temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:ipm_temperature | Intelligent Power Management temperature |
+| 3095 | Boost temperature | Boost inductor temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:boost_temperature | Boost temperature |
+| 3097 | Communication board temperature | Temperature reported by the communication/control board (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:comm_board_temperature | Comm board temperature |
+| 3098 | P-bus voltage | Positive DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | tlx:p_bus_voltage | P-bus voltage |
+| 3099 | N-bus voltage | Negative DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | tlx:n_bus_voltage | N-bus voltage |
+| 3101 | Output power percentage | Instantaneous AC output as a percentage of the inverter's rated power. | R | — % | — | u 16_percent | tlx:real_output_power_percent | Real power output percentage |
+| 3105 | Fault code | Current inverter fault code (see protocol documentation). | R | — | — | u 16_status_word | tlx:fault_code | Fault code |
+| 3110 | Warning code | Current inverter warning code (vendor-defined bitmask). | R | — | — | u 16_status_word | tlx:warning_code | Warning code |
+| 3111 | Present FFT value (channel A) | Latest Fast Fourier Transform diagnostic value for channel A. | R | — | — | u 16_raw | tlx:present_fft_a | Present FFT A |
+| 3115 | Inverter start delay | Seconds remaining before restart once grid conditions recover. | R | — s | — | u 16_raw | tlx:inv_start_delay | Inverter start delay |
+
+## TL-X/TL-XH Battery & Hybrid Input Registers (3125–3249)
+Battery energy, power flow, and BMS telemetry for TL-XH hybrids.
+
+**Applies to:** TL-X/TL-XH hybrids, Storage TL-XH
+
+| Register | Name | Description | Access | Range/Unit | Initial | Notes | Attributes | Sensors |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 3125 | Battery discharge today | Energy discharged from the battery into the AC system today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:discharge_energy_today, storage:discharge_energy_today | Battery Discharged (Today), Battery Discharged Today |
+| 3127 | Battery discharge total | Total energy discharged from the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:discharge_energy_total, storage:discharge_energy_total | Battery Discharged (Total), Battery Discharged Lifetime |
+| 3129 | Battery charge today | Energy charged into the battery today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:charge_energy_today, storage:charge_energy_today | Battery Charged (Today), Battery Charged Today |
+| 3131 | Battery charge total | Total energy charged into the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:charge_energy_total, storage:charge_energy_total | Battery Charged (Total), Grid Charged Lifetime |
+| 3164 | BDC presence flag | Indicates whether a battery DC converter (BDC) has been detected. | R | — | — | u 16_flag | tlx:bdc_new_flag, storage:bdc_new_flag | BDC present |
+| 3169 | Battery voltage | Pack voltage reported via the inverter-side measurements (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | tlx:battery_voltage, storage:battery_voltage | Battery voltage |
+| 3170 | Battery current | Current flowing between battery and inverter (positive = discharge) with 0.1 A resolution. | R | — A | — | s 16_current_deciamp | tlx:battery_current, storage:battery_current | Battery current |
+| 3171 | Battery SOC | Battery state of charge reported by the inverter. | R | — % | — | u 16_percent | tlx:soc, storage:soc | SOC |
+| 3172 | VBUS 1 voltage | BDC high-side bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | tlx:vbus1_voltage, storage:vbus1_voltage | VBUS1 voltage |
+| 3173 | VBUS 2 voltage | BDC low-side bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | tlx:vbus2_voltage, storage:vbus2_voltage | VBUS2 voltage |
+| 3174 | Buck/boost current | Current through the BDC buck/boost stage (0.1 A resolution). | R | — A | — | u 16_current_deciamp | tlx:buck_boost_current, storage:buck_boost_current | Buck/boost current |
+| 3175 | LLC stage current | Current through the LLC resonant stage (0.1 A resolution). | R | — A | — | u 16_current_deciamp | tlx:llc_current, storage:llc_current | LLC current |
+| 3176 | Battery temperature A | Battery temperature sensor A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:battery_temperature_a, storage:battery_temperature_a | Battery temperature A |
+| 3177 | Battery temperature B | Battery temperature sensor B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:battery_temperature_b, storage:battery_temperature_b | Battery temperature B |
+| 3178 | Battery discharge power | Real-time discharge power flowing from the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | tlx:discharge_power, storage:discharge_power | Battery discharge power, Discharge Power |
+| 3180 | Battery charge power | Real-time charge power flowing into the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | tlx:charge_power, storage:charge_power | Battery charge power, Charge Power |
+| 3189 | BMS max cell index | Cell index reporting the highest voltage in the battery stack (1-based). | R | — | — | u 16_raw | tlx:bms_max_volt_cell_no, storage:bms_max_volt_cell_no | BMS max volt cell no |
+| 3190 | BMS min cell index | Cell index reporting the lowest voltage in the battery stack (1-based). | R | — | — | u 16_raw | tlx:bms_min_volt_cell_no, storage:bms_min_volt_cell_no | BMS min volt cell no |
+| 3191 | BMS average temperature A | Average temperature reported by sensor group A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:bms_avg_temp_a, storage:bms_avg_temp_a | BMS avg temp A |
+| 3192 | BMS max cell temperature A | Maximum cell temperature within sensor group A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:bms_max_cell_temp_a, storage:bms_max_cell_temp_a | BMS max cell temp A |
+| 3193 | BMS average temperature B | Average temperature reported by sensor group B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:bms_avg_temp_b, storage:bms_avg_temp_b | BMS avg temp B |
+| 3194 | BMS max cell temperature B | Maximum cell temperature within sensor group B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:bms_max_cell_temp_b, storage:bms_max_cell_temp_b | BMS max cell temp B |
+| 3195 | BMS average temperature C | Average temperature reported by sensor group C (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:bms_avg_temp_c, storage:bms_avg_temp_c | BMS avg temp C |
+| 3196 | BMS max SOC | Highest state of charge observed across battery modules. | R | — % | — | u 16_percent | tlx:bms_max_soc, storage:bms_max_soc | BMS max SOC |
+| 3197 | BMS min SOC | Lowest state of charge observed across battery modules. | R | — % | — | u 16_percent | tlx:bms_min_soc, storage:bms_min_soc | BMS min SOC |
+| 3198 | Parallel battery count | Number of battery modules detected in parallel. | R | — | — | u 16_raw | tlx:parallel_battery_num, storage:parallel_battery_num | — |
+| 3199 | BMS derate reason | Reason code reported by the BMS for power derating. | R | — | — | u 16_raw | tlx:bms_derate_reason, storage:bms_derate_reason | BMS derate reason |
+| 3200 | BMS full charge capacity | Full charge capacity (FCC) reported by the battery fuel gauge (Ah). | R | — Ah | — | u 16_ampere_hour | tlx:bms_gauge_fcc_ah, storage:bms_gauge_fcc_ah | BMS full charge capacity |
+| 3201 | BMS remaining capacity | Remaining capacity (RM) reported by the battery fuel gauge (Ah). | R | — Ah | — | u 16_ampere_hour | tlx:bms_gauge_rm_ah, storage:bms_gauge_rm_ah | BMS remaining capacity |
+| 3202 | BMS protect flags 1 | Protection bitmask word 1 from the battery management system. | R | — | — | u 16_raw | tlx:bms_protect1, storage:bms_protect1 | BMS protect 1 |
+| 3203 | BMS warning flags 1 | Warning bitmask word 1 from the battery management system. | R | — | — | u 16_raw | tlx:bms_warn1, storage:bms_warn1 | BMS warn 1 |
+| 3204 | BMS fault flags 1 | Fault bitmask word 1 from the battery management system. | R | — | — | u 16_raw | tlx:bms_fault1, storage:bms_fault1 | BMS fault 1 |
+| 3205 | BMS fault flags 2 | Fault bitmask word 2 from the battery management system. | R | — | — | u 16_raw | tlx:bms_fault2, storage:bms_fault2 | BMS fault 2 |
+| 3210 | Battery insulation status | Isolation detection status reported by the BMS (0 = not detected, 1 = detected). | R | — | — | u 16_raw | tlx:bat_iso_status, storage:bat_iso_status | — |
+| 3211 | Battery request flags | Bitmask of requests from the BMS to the inverter (charge/discharge permissions). | R | — | — | u 16_raw | tlx:batt_request_flags, storage:batt_request_flags | — |
+| 3212 | BMS status | Overall battery management system status code. | R | — | — | u 16_raw | tlx:bms_status, storage:bms_status | BMS status |
+| 3213 | BMS protect flags 2 | Protection bitmask word 2 from the battery management system. | R | — | — | u 16_raw | tlx:bms_protect2, storage:bms_protect2 | BMS protect 2 |
+| 3214 | BMS warning flags 2 | Warning bitmask word 2 from the battery management system. | R | — | — | u 16_raw | tlx:bms_warn2, storage:bms_warn2 | BMS warn 2 |
+| 3215 | BMS SOC | State of charge reported directly by the BMS. | R | — % | — | u 16_percent | tlx:bms_soc, storage:bms_soc | BMS SOC |
+| 3216 | BMS battery voltage | Pack voltage reported by the BMS (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | tlx:bms_battery_voltage, storage:bms_battery_voltage | BMS battery voltage |
+| 3217 | BMS battery current | Current reported by the BMS with 0.01 A resolution (positive = discharge). | R | — A | — | s 16_current_centiamp; Positive values indicate discharge from the battery; negative values indicate charging. | tlx:bms_battery_current, storage:bms_battery_current | BMS battery current |
+| 3218 | BMS max cell temperature | Maximum cell temperature observed across the battery pack (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:bms_cell_max_temp, storage:bms_cell_max_temp | BMS cell max temperature |
+| 3219 | BMS max charge current | Maximum charge current allowed by the BMS (0.01 A resolution). | R | — A | — | u 16_current_centiamp | tlx:bms_max_charge_current, storage:bms_max_charge_current | BMS max charge current |
+| 3220 | BMS max discharge current | Maximum discharge current allowed by the BMS (0.01 A resolution). | R | — A | — | u 16_current_centiamp | tlx:bms_max_discharge_current, storage:bms_max_discharge_current | BMS max discharge current |
+| 3221 | BMS cycle count | Total charge/discharge cycles counted by the BMS. | R | — | — | u 16_raw | tlx:bms_cycle_count, storage:bms_cycle_count | BMS cycle count |
+| 3222 | BMS state of health | Battery state of health reported by the BMS. | R | — % | — | u 16_percent | tlx:bms_soh, storage:bms_soh | BMS SOH |
+| 3223 | BMS charge voltage limit | Maximum pack voltage permitted during charge (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | tlx:bms_charge_volt_limit, storage:bms_charge_volt_limit | BMS charge voltage limit |
+| 3224 | BMS discharge voltage limit | Minimum pack voltage permitted during discharge (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | tlx:bms_discharge_volt_limit, storage:bms_discharge_volt_limit | BMS discharge voltage limit |
+| 3225 | BMS warning flags 3 | Warning bitmask word 3 from the battery management system. | R | — | — | u 16_raw | tlx:bms_warn3, storage:bms_warn3 | BMS warn 3 |
+| 3226 | BMS protect flags 3 | Protection bitmask word 3 from the battery management system. | R | — | — | u 16_raw | tlx:bms_protect3, storage:bms_protect3 | BMS protect 3 |
+| 3230 | BMS max cell voltage | Highest individual cell voltage (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | tlx:bms_cell_volt_max, storage:bms_cell_volt_max | BMS cell voltage max |
+| 3231 | BMS min cell voltage | Lowest individual cell voltage (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | tlx:bms_cell_volt_min, storage:bms_cell_volt_min | BMS cell voltage min |
+
+## Storage TL-XH Input Registers (3041–3231)
+BDC telemetry (battery module data) for TL-XH hybrids.
+
+**Applies to:** Storage TL-XH
+
+| Register | Name | Description | Access | Range/Unit | Initial | Notes | Attributes | Sensors |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 3041 | Load supply power | Real-time active power delivered to on-site (self-consumption) loads. | R | — W | — | u 32_power_w_decawatt | storage:power_to_user | Power to user |
+| 3043 | Grid export power | Active power exported to the utility grid. | R | — W | — | u 32_power_w_decawatt | storage:power_to_grid | Power to grid |
+| 3045 | Home load power | Aggregate instantaneous demand from on-site loads. | R | — W | — | u 32_power_w_decawatt | storage:power_user_load | Power user load |
+| 3047 | Run time | Total cumulative run time of the inverter. Raw values are seconds scaled by 1/7200 (0.0001389 hours). | R | — h | — | u 32_runtime_hours; Raw counter counts seconds; divide by 7200 to obtain hours. | — | — |
+| 3049 | Output energy today | Energy exported to the AC output today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3051 | Output energy total | Lifetime AC output energy (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3053 | PV energy total | Total PV energy generated across all strings (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3055 | PV 1 energy today | Energy harvested by PV 1 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3057 | PV 1 energy total | Lifetime energy harvested by PV 1. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3059 | PV 2 energy today | Energy harvested by PV 2 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3061 | PV 2 energy total | Lifetime energy harvested by PV 2. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3063 | PV 3 energy today | Energy harvested by PV 3 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3065 | PV 3 energy total | Lifetime energy harvested by PV 3. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3067 | Load energy today | Energy delivered to on-site loads today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:energy_to_user_today | Energy To User (Today) |
+| 3069 | Load energy total | Lifetime energy delivered to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:energy_to_user_total | Energy To User (Total) |
+| 3071 | Export energy today | Energy exported to the grid today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:energy_to_grid_today | Energy To Grid (Today) |
+| 3073 | Export energy total | Lifetime energy exported to the grid (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:energy_to_grid_total | Energy To Grid (Total) |
+| 3086 | Derating mode | Active derating reason reported by the inverter controller. | R | — | — | u 16_raw_code | — | — |
+| 3093 | Inverter temperature | Main inverter heatsink temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3094 | IPM temperature | IPM (power module) temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3095 | Boost temperature | Boost inductor temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3097 | Communication board temperature | Temperature reported by the communication/control board (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:comm_board_temperature | Comm board temperature |
+| 3098 | P-bus voltage | Positive DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3099 | N-bus voltage | Negative DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3101 | Output power percentage | Instantaneous AC output as a percentage of the inverter's rated power. | R | — % | — | u 16_percent | — | — |
+| 3105 | Fault code | Current inverter fault code (see protocol documentation). | R | — | — | u 16_status_word | — | — |
+| 3110 | Warning code | Current inverter warning code (vendor-defined bitmask). | R | — | — | u 16_status_word | — | — |
+| 3111 | Present FFT value (channel A) | Latest Fast Fourier Transform diagnostic value for channel A. | R | — | — | u 16_raw | storage:present_fft_a | Present FFT A |
+| 3115 | Inverter start delay | Seconds remaining before restart once grid conditions recover. | R | — s | — | u 16_raw | storage:inv_start_delay | Inverter start delay |
+| 3125 | Battery discharge today | Energy discharged from the battery into the AC system today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:discharge_energy_today | Battery Discharged (Today), Battery Discharged Today |
+| 3127 | Battery discharge total | Total energy discharged from the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:discharge_energy_total | Battery Discharged (Total), Battery Discharged Lifetime |
+| 3129 | Battery charge today | Energy charged into the battery today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:charge_energy_today | Battery Charged (Today), Battery Charged Today |
+| 3131 | Battery charge total | Total energy charged into the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:charge_energy_total | Battery Charged (Total), Grid Charged Lifetime |
+| 3164 | BDC presence flag | Indicates whether a battery DC converter (BDC) has been detected. | R | — | — | u 16_flag | storage:bdc_new_flag | BDC present |
+| 3169 | Battery voltage | Pack voltage reported via the inverter-side measurements (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | storage:battery_voltage | Battery voltage |
+| 3170 | Battery current | Current flowing between battery and inverter (positive = discharge) with 0.1 A resolution. | R | — A | — | s 16_current_deciamp | storage:battery_current | Battery current |
+| 3171 | Battery SOC | Battery state of charge reported by the inverter. | R | — % | — | u 16_percent | storage:soc | SOC |
+| 3172 | VBUS 1 voltage | BDC high-side bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | storage:vbus1_voltage | VBUS1 voltage |
+| 3173 | VBUS 2 voltage | BDC low-side bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | storage:vbus2_voltage | VBUS2 voltage |
+| 3174 | Buck/boost current | Current through the BDC buck/boost stage (0.1 A resolution). | R | — A | — | u 16_current_deciamp | storage:buck_boost_current | Buck/boost current |
+| 3175 | LLC stage current | Current through the LLC resonant stage (0.1 A resolution). | R | — A | — | u 16_current_deciamp | storage:llc_current | LLC current |
+| 3176 | Battery temperature A | Battery temperature sensor A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:battery_temperature_a | Battery temperature A |
+| 3177 | Battery temperature B | Battery temperature sensor B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:battery_temperature_b | Battery temperature B |
+| 3178 | Battery discharge power | Real-time discharge power flowing from the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | storage:discharge_power | Battery discharge power, Discharge Power |
+| 3180 | Battery charge power | Real-time charge power flowing into the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | storage:charge_power | Battery charge power, Charge Power |
+| 3189 | BMS max cell index | Cell index reporting the highest voltage in the battery stack (1-based). | R | — | — | u 16_raw | storage:bms_max_volt_cell_no | BMS max volt cell no |
+| 3190 | BMS min cell index | Cell index reporting the lowest voltage in the battery stack (1-based). | R | — | — | u 16_raw | storage:bms_min_volt_cell_no | BMS min volt cell no |
+| 3191 | BMS average temperature A | Average temperature reported by sensor group A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:bms_avg_temp_a | BMS avg temp A |
+| 3192 | BMS max cell temperature A | Maximum cell temperature within sensor group A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:bms_max_cell_temp_a | BMS max cell temp A |
+| 3193 | BMS average temperature B | Average temperature reported by sensor group B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:bms_avg_temp_b | BMS avg temp B |
+| 3194 | BMS max cell temperature B | Maximum cell temperature within sensor group B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:bms_max_cell_temp_b | BMS max cell temp B |
+| 3195 | BMS average temperature C | Average temperature reported by sensor group C (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:bms_avg_temp_c | BMS avg temp C |
+| 3196 | BMS max SOC | Highest state of charge observed across battery modules. | R | — % | — | u 16_percent | storage:bms_max_soc | BMS max SOC |
+| 3197 | BMS min SOC | Lowest state of charge observed across battery modules. | R | — % | — | u 16_percent | storage:bms_min_soc | BMS min SOC |
+| 3198 | Parallel battery count | Number of battery modules detected in parallel. | R | — | — | u 16_raw | storage:parallel_battery_num | — |
+| 3199 | BMS derate reason | Reason code reported by the BMS for power derating. | R | — | — | u 16_raw | storage:bms_derate_reason | BMS derate reason |
+| 3200 | BMS full charge capacity | Full charge capacity (FCC) reported by the battery fuel gauge (Ah). | R | — Ah | — | u 16_ampere_hour | storage:bms_gauge_fcc_ah | BMS full charge capacity |
+| 3201 | BMS remaining capacity | Remaining capacity (RM) reported by the battery fuel gauge (Ah). | R | — Ah | — | u 16_ampere_hour | storage:bms_gauge_rm_ah | BMS remaining capacity |
+| 3202 | BMS protect flags 1 | Protection bitmask word 1 from the battery management system. | R | — | — | u 16_raw | storage:bms_protect1 | BMS protect 1 |
+| 3203 | BMS warning flags 1 | Warning bitmask word 1 from the battery management system. | R | — | — | u 16_raw | storage:bms_warn1 | BMS warn 1 |
+| 3204 | BMS fault flags 1 | Fault bitmask word 1 from the battery management system. | R | — | — | u 16_raw | storage:bms_fault1 | BMS fault 1 |
+| 3205 | BMS fault flags 2 | Fault bitmask word 2 from the battery management system. | R | — | — | u 16_raw | storage:bms_fault2 | BMS fault 2 |
+| 3210 | Battery insulation status | Isolation detection status reported by the BMS (0 = not detected, 1 = detected). | R | — | — | u 16_raw | storage:bat_iso_status | — |
+| 3211 | Battery request flags | Bitmask of requests from the BMS to the inverter (charge/discharge permissions). | R | — | — | u 16_raw | storage:batt_request_flags | — |
+| 3212 | BMS status | Overall battery management system status code. | R | — | — | u 16_raw | storage:bms_status | BMS status |
+| 3213 | BMS protect flags 2 | Protection bitmask word 2 from the battery management system. | R | — | — | u 16_raw | storage:bms_protect2 | BMS protect 2 |
+| 3214 | BMS warning flags 2 | Warning bitmask word 2 from the battery management system. | R | — | — | u 16_raw | storage:bms_warn2 | BMS warn 2 |
+| 3215 | BMS SOC | State of charge reported directly by the BMS. | R | — % | — | u 16_percent | storage:bms_soc | BMS SOC |
+| 3216 | BMS battery voltage | Pack voltage reported by the BMS (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | storage:bms_battery_voltage | BMS battery voltage |
+| 3217 | BMS battery current | Current reported by the BMS with 0.01 A resolution (positive = discharge). | R | — A | — | s 16_current_centiamp; Positive values indicate discharge from the battery; negative values indicate charging. | storage:bms_battery_current | BMS battery current |
+| 3218 | BMS max cell temperature | Maximum cell temperature observed across the battery pack (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:bms_cell_max_temp | BMS cell max temperature |
+| 3219 | BMS max charge current | Maximum charge current allowed by the BMS (0.01 A resolution). | R | — A | — | u 16_current_centiamp | storage:bms_max_charge_current | BMS max charge current |
+| 3220 | BMS max discharge current | Maximum discharge current allowed by the BMS (0.01 A resolution). | R | — A | — | u 16_current_centiamp | storage:bms_max_discharge_current | BMS max discharge current |
+| 3221 | BMS cycle count | Total charge/discharge cycles counted by the BMS. | R | — | — | u 16_raw | storage:bms_cycle_count | BMS cycle count |
+| 3222 | BMS state of health | Battery state of health reported by the BMS. | R | — % | — | u 16_percent | storage:bms_soh | BMS SOH |
+| 3223 | BMS charge voltage limit | Maximum pack voltage permitted during charge (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | storage:bms_charge_volt_limit | BMS charge voltage limit |
+| 3224 | BMS discharge voltage limit | Minimum pack voltage permitted during discharge (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | storage:bms_discharge_volt_limit | BMS discharge voltage limit |
+| 3225 | BMS warning flags 3 | Warning bitmask word 3 from the battery management system. | R | — | — | u 16_raw | storage:bms_warn3 | BMS warn 3 |
+| 3226 | BMS protect flags 3 | Protection bitmask word 3 from the battery management system. | R | — | — | u 16_raw | storage:bms_protect3 | BMS protect 3 |
+| 3230 | BMS max cell voltage | Highest individual cell voltage (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | storage:bms_cell_volt_max | BMS cell voltage max |
+| 3231 | BMS min cell voltage | Lowest individual cell voltage (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | storage:bms_cell_volt_min | BMS cell voltage min |
 
 ## Offgrid SPF Input Registers
 Observed off-grid register map (from integration implementation).
@@ -1296,888 +690,179 @@ Observed off-grid register map (from integration implementation).
 
 | Register | Name | Description | Access | Range/Unit | Initial | Notes | Attributes | Sensors |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 0 | Status code | Inverter run state | — | — | — | — | offgrid:status_code | Status code |
-| 1 | Input 1 voltage | Input power (high) | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 2 | Input 2 voltage | Input power (low) | — | — | — | — | offgrid:input_2_voltage | Input 2 voltage, PV2 voltage |
-| 3 | Input 1 Wattage | PV 1 voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 4 | Input 1 Amperage | PV 1 input current | — | — | — | — | — | — |
-| 5 | Input 1 Wattage | PV 1 input power(high) | — | — | — | — | offgrid:input_2_power | Input 2 Wattage, PV2 charge power |
-| 6 | Ppv 1 L | PV 1 input power(low) | — | — | — | — | — | — |
-| 7 | Input 1 Amperage | PV 2 voltage | — | — | — | — | offgrid:input_1_amperage | Input 1 Amperage, PV1 buck current |
-| 8 | Input 2 Amperage | PV 2 input current | — | — | — | — | offgrid:input_2_amperage | Input 2 Amperage, PV2 buck current |
-| 9 | Input 2 Wattage | PV 2 input power (high) | — | — | — | — | offgrid:output_active_power | Output active power |
-| 10 | . Ppv 2 L | PV 2 input power (low) | — | — | — | — | — | — |
-| 11 | Input 3 voltage | PV 3 voltage | — | — | — | — | — | — |
-| 12 | Input 3 Amperage | PV 3 input current | — | — | — | — | — | — |
-| 13 | AC frequency | PV 3 input power (high) | — | — | — | — | offgrid:charge_power | Battery charge power, Charge Power |
-| 14 | Output 1 voltage | PV 3 input power (low) | — | — | — | — | — | — |
-| 15 | Input 4 voltage | PV 4 voltage | — | — | — | — | — | — |
-| 16 | Input 4 Amperage | PV 4 input current | — | — | — | — | — | — |
-| 17 | Battery voltage | PV 4 input power (high) | — | — | — | — | offgrid:battery_voltage | Battery voltage |
-| 18 | Output 2 voltage | PV 4 input power (low) | — | — | — | — | offgrid:soc | SOC |
-| 19 | Bus voltage | PV 5 voltage | — | — | — | — | offgrid:bus_voltage | Bus voltage |
-| 20 | Grid voltage | PV 5 input current | — | — | — | — | offgrid:grid_voltage | Grid voltage |
-| 21 | AC frequency | PV 5 input power(high) | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 22 | Output 1 voltage | PV 5 input power(low) | — | — | — | — | offgrid:output_1_voltage | Output 1 voltage, Output voltage |
-| 23 | Input 6 voltage | PV 6 voltage | — | — | — | — | offgrid:output_frequency | Output frequency |
-| 24 | Input 6 Amperage | PV 6 input current | — | — | — | — | offgrid:output_dc_voltage | Output DC voltage |
-| 25 | Input 6 Wattage | PV 6 input power (high) | — | — | — | — | offgrid:inverter_temperature | Temperature |
-| 26 | DC-DC temperature | PV 6 input power (low) | — | — | — | — | offgrid:dc_dc_temperature | DC-DC temperature |
-| 27 | Input 7 voltage | PV 7 voltage | — | — | — | — | offgrid:load_percent | Inverter load |
-| 28 | Battery port voltage | PV 7 input current | — | — | — | — | offgrid:battery_port_voltage | Battery port voltage |
-| 29 | Battery bus voltage | PV 7 input power (high) | — | — | — | — | offgrid:battery_bus_voltage | Battery bus voltage |
-| 30 | Running hours | PV 7 input power (low) | — | — | — | — | offgrid:operation_hours | Running hours |
-| 31 | Input 8 voltage | PV 8 voltage | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV 8 input current | — | — | — | — | — | — |
-| 33 | Input 8 Wattage | PV 8 input power (high) | — | — | — | — | — | — |
-| 34 | Output 1 Amperage | PV 8 input power (low) | — | — | — | — | offgrid:output_1_amperage | Output 1 Amperage, Output amperage |
-| 35 | Output power | Output power (high) | — | — | — | — | — | — |
-| 36 | . Pac L | Output power (low) | — | — | — | — | — | — |
-| 37 | AC frequency | Grid frequency | — | — | — | — | — | — |
-| 38 | Output 1 voltage | Three/single phase grid voltage | — | — | — | — | — | — |
-| 39 | Output 1 Amperage | Three/single phase grid output | — | — | — | — | — | — |
-| 40 | Fault code | Three/single phase grid output VA (high) | — | — | — | — | — | — |
-| 41 | Intelligent Power Management temperature | Three/single phase grid output VA(low) | — | — | — | — | — | — |
-| 42 | Fault code | Three phase grid voltage | — | — | — | — | offgrid:fault_code | Fault code |
-| 43 | N-bus voltage | Three phase grid output current | — | — | — | — | offgrid:warning_code | Warning code |
-| 44 | Output 2 Wattage | Three phase grid output power ( | — | — | — | — | — | — |
-| 45 | . Pac 2 L | Three phase grid output power ( | — | — | — | — | — | — |
-| 46 | Output 3 voltage | Three phase grid voltage | — | — | — | — | — | — |
-| 47 | Derating mode | Three phase grid output current | — | — | — | — | offgrid:constant_power | — |
-| 48 | Input 1 energy today | Three phase grid output power ( | — | — | — | — | offgrid:input_1_energy_today | Input 1 energy today, PV1 energy produced today |
-| 49 | . Pac 3 L | Three phase grid output power ( | — | — | — | — | — | — |
-| 50 | Input 1 total energy | Three phase grid voltage | — | — ne voltage | — | — | offgrid:input_1_energy_total | Input 1 total energy, PV1 energy produced Lifetime |
-| 51 | . Vac_ST | Three phase grid voltage | — | — ne voltage | — | — | — | — |
-| 52 | Input 2 energy today | Three phase grid voltage | — | — ne voltage | — | — | offgrid:input_2_energy_today | Input 2 energy today, PV2 energy produced today |
-| 53 | Energy produced today | Today generate energy (high) | — | — | — | — | — | — |
-| 54 | Input 2 total energy | Today generate energy (low) | — | — | — | — | offgrid:input_2_energy_total | Input 2 total energy, PV2 energy produced Lifetime |
-| 55 | Total energy produced | Total generate energy (high) | — | — | — | — | — | — |
-| 56 | Battery Charged (Today) | Total generate energy (low) | — | — | — | — | offgrid:charge_energy_today | Battery Charged (Today), Battery Charged Today |
-| 57 | Running hours | Work time total (high) | — | — | — | — | — | — |
-| 58 | Battery Charged (Total) | Work time total (low) | — | — | — | — | offgrid:charge_energy_total | Battery Charged (Total), Grid Charged Lifetime |
-| 59 | Input 1 energy today | PV 1 Energy today(high) | — | — | — | — | — | — |
-| 60 | Battery Discharged (Today) | PV 1 Energy today (low) | — | — | — | — | offgrid:discharge_energy_today | Battery Discharged (Today), Battery Discharged Today |
-| 61 | Input 1 total energy | PV 1 Energy total(high) | — | — | — | — | — | — |
-| 62 | Battery Discharged (Total) | PV 1 Energy total (low) | — | — | — | — | offgrid:discharge_energy_total | Battery Discharged (Total), Battery Discharged Lifetime |
-| 63 | Input 2 energy today | PV 2 Energy today(high) | — | — | — | — | — | — |
-| 64 | AC Discharged Today | PV 2 Energy today (low) | — | — h | — | — | offgrid:ac_discharge_energy_today | AC Discharged Today |
-| 65 | Input 2 total energy | PV 2 Energy total(high) | — | — h | — | — | — | — |
-| 66 | Grid Discharged Lifetime | PV 2 Energy total (low) | — | — h | — | — | offgrid:ac_discharge_energy_total | Grid Discharged Lifetime |
-| 67 | Input 3 energy today | PV 3 Energy today(high) | — | — h | — | — | — | — |
-| 68 | AC charge battery current | PV 3 Energy today (low) | — | — h | — | — | offgrid:ac_charge_amperage | AC charge battery current |
-| 69 | Battery discharge power | PV 3 Energy total(high) | — | — h | — | — | offgrid:discharge_power | Battery discharge power, Discharge Power |
-| 70 | . Epv 3_total L | PV 3 Energy total (low) | — | — h | — | — | — | — |
-| 71 | Input 4 energy today | PV 4 Energy today(high) | — | — h | — | — | — | — |
-| 72 | . Epv 4_today L | PV 4 Energy today (low) | — | — h | — | — | — | — |
-| 73 | Battery discharge current | PV 4 Energy total(high) | — | — h | — | — | offgrid:battery_discharge_amperage | Battery discharge current |
-| 74 | . Epv 4_total L | PV 4 Energy total (low) | — | — h | — | — | — | — |
-| 75 | Input 5 energy today | PV 5 Energy today(high) | — | — h | — | — | — | — |
-| 76 | . Epv 5_today L | PV 5 Energy today (low) | — | — h | — | — | — | — |
-| 77 | Battery charging/ discharging(-ve) | PV 5 Energy total(high) | — | — h | — | — | offgrid:battery_power | Battery charging/ discharging(-ve) |
-| 78 | . Epv 5_total L | PV 5 Energy total (low) | — | — h | — | — | — | — |
-| 79 | Input 6 energy today | PV 6 Energy today(high) | — | — h | — | — | — | — |
-| 80 | . Epv 6_today L | PV 6 Energy today (low) | — | — h | — | — | — | — |
-| 81 | Input 6 total energy | PV 6 Energy total(high) | — | — h | — | — | — | — |
-| 82 | . Epv 6_total L | PV 6 Energy total (low) | — | — h | — | — | — | — |
-| 83 | Input 7 energy today | PV 7 Energy today(high) | — | — h | — | — | — | — |
-| 84 | . Epv 7_today L | PV 7 Energy today (low) | — | — h | — | — | — | — |
-| 85 | Input 7 total energy | PV 7 Energy total(high) | — | — h | — | — | — | — |
-| 86 | . Epv 7_total L | PV 7 Energy total (low) | — | — h | — | — | — | — |
-| 87 | Input 8 energy today | PV 8 Energy today(high) | — | — h | — | — | — | — |
-| 88 | . Epv 8_today L | PV 8 Energy today (low) | — | — h | — | — | — | — |
-| 89 | Input 8 total energy | PV 8 Energy total(high) | — | — h | — | — | — | — |
-| 90 | . Epv 8_total L | PV 8 Energy total (low) | — | — h | — | — | — | — |
-| 91 | Total energy input | PV Energy total(high) | — | — h | — | — | — | — |
-| 92 | . Epv_total L | PV Energy total (low) | — | — h | — | — | — | — |
-| 93 | Temperature | Inverter temperature | — | — | — | — | — | — |
-| 94 | Intelligent Power Management temperature | The inside IPM in inverter Temp | — | — | — | — | — | — |
-| 95 | Boost temperature | Boost temperature | — | — | — | — | — | — |
-| 96 | . Temp 4 | — | — | — reserved | — | — | — | — |
-| 97 | . uw Bat Volt_DSP | Bat Volt_DSP | — | — Bat Volt(DSP) | — | — | — | — |
-| 98 | P-bus voltage | P Bus inside Voltage | — | — | — | — | — | — |
-| 99 | N-bus voltage | N Bus inside Voltage | — | — | — | — | — | — |
-| 10 | 0. IPF | Inverter output PF now | — | — | — | — | — | — |
-| 10 | 1. Real OPPercent | Real Output power Percent | — | — | — | — | — | — |
-| 10 | 2. OPFullwatt H | Output Maxpower Limited high | — | — | — | — | — | — |
-| 10 | 3. OPFullwatt L | Output Maxpower Limited low | — | — | — | — | — | — |
-| 10 | 4. Derating Mode | Derating Mode 0 1 2 3 4 5 6 7 8 9 B | — | — | — | — | — | — |
-| 10 | 5. Fault Maincode | Inverter fault maincode | — | — | — | — | — | — |
-| 10 | 6. | — | — | — | — | — | — | — |
-| 10 | 7. Fault Subcode | Inverter fault subcode | — | — | — | — | — | — |
-| 10 | 8. Remote Ctrl En | / 0 1 | — | — orage Pow (SPA) | — | — | — | — |
-| 10 | 9. Remote Ctrl Pow er | / 2 | — | — orage Pow (SPA) | — | — | — | — |
-| 11 | Input 3 voltage | Warning bit H | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Inverter warn subcode | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Inverter warn maincode ACCharge energy today | — | — orage wer | — | — | — | — |
-| 11 | Input 3 voltage | real Power Percent 0 ACCharge energy today | — | — X orage wer | — | — | — | — |
-| 11 | Input 3 voltage | nv start delay time ACCharge energy total | — | — X orage wer | — | — | — | — |
-| 11 | Input 3 voltage | b INVAll Fault Code ACCharge energy total | — | — X orage wer | — | — | — | — |
-| 11 | Input 3 voltage | Grid power to local load | — | — orage wer | — | — | — | — |
-| 11 | Input 3 voltage | Grid power to local load | — | — orage wer | — | — | — | — |
-| 11 | Input 3 voltage | 0:Load First 1:Battery First 2:Grid First | — | — orage Power | — | — | — | — |
-| 11 | Input 3 voltage | 0:Lead-acid 1:Lithium battery | — | — Storage Power | — | — | — | — |
-| 12 | Input 3 Amperage | Aging mode Auto-cal command | — | — Storage Power | — | — | — | — |
-| 12 | Input 3 Amperage | — | — | — reserved | — | — | — | — |
-| 12 | Input 3 Amperage | PID PV 1 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | — | — |
-| 12 | Input 3 Amperage | PID PV 1 PE Curr | — | — m A | — | — | — | — |
-| 12 | Input 3 Amperage | PID PV 2 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | — | — |
-| 12 | Input 3 Amperage | PID PV 2 PE Curr | — | — m A | — | — | — | — |
-| 12 | Input 3 Amperage | PID PV 3 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | — | — |
-| 13 | AC frequency | PID PV 3 PE Curr | — | — m A | — | — | offgrid:charge_power | Battery charge power, Charge Power |
-| 13 | AC frequency | PID PV 4 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | offgrid:charge_power | Battery charge power, Charge Power |
-| 13 | AC frequency | PID PV 4 PE Curr | — | — m A | — | — | offgrid:charge_power | Battery charge power, Charge Power |
-| 13 | AC frequency | PID PV 5 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | offgrid:charge_power | Battery charge power, Charge Power |
-| 13 | AC frequency | PID PV 5 PE Curr | — | — m A | — | — | offgrid:charge_power | Battery charge power, Charge Power |
-| 13 | AC frequency | PID PV 6 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | offgrid:charge_power | Battery charge power, Charge Power |
-| 13 | AC frequency | PID PV 6 PE Curr | — | — m A | — | — | offgrid:charge_power | Battery charge power, Charge Power |
-| 13 | AC frequency | PID PV 7 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | offgrid:charge_power | Battery charge power, Charge Power |
-| 13 | AC frequency | PID PV 7 PE Curr | — | — m A | — | — | offgrid:charge_power | Battery charge power, Charge Power |
-| 13 | AC frequency | PID PV 8 PE Volt/ Flyspan volta (MAX HV) | — | — V | — | — | offgrid:charge_power | Battery charge power, Charge Power |
-| 14 | Output 1 voltage | PID PV 8 PE Curr | — | — m A | — | — | — | — |
-| 14 | Output 1 voltage | Bit 0~7:PID Working Status 1:Wait Status 2:Normal Status 3:Fault Status Bit 8~15:Reversed | — | — | — | — | — | — |
-| 14 | Output 1 voltage | PV String 1 voltage | — | — V | — | — | — | — |
-| 14 | Output 1 voltage | PV String 1 current | — | — A | — | — | — | — |
-| 14 | Output 1 voltage | PV String 2 voltage | — | — V | — | — | — | — |
-| 14 | Output 1 voltage | PV String 2 current | — | — | — | — | — | — |
-| 14 | Output 1 voltage | PV String 3 voltage | — | — | — | — | — | — |
-| 14 | Output 1 voltage | PV String 3 current | — | — | — | — | — | — |
-| 14 | Output 1 voltage | PV String 4 voltage | — | — | — | — | — | — |
-| 14 | Output 1 voltage | PV String 4 current | — | — | — | — | — | — |
-| 15 | Input 4 voltage | PV String 5 voltage | — | — | — | — | — | — |
-| 15 | Input 4 voltage | PV String 5 current | — | — | — | — | — | — |
-| 15 | Input 4 voltage | PV String 6 voltage | — | — | — | — | — | — |
-| 15 | Input 4 voltage | PV String 6 current | — | — | — | — | — | — |
-| 15 | Input 4 voltage | PV String 7 voltage | — | — | — | — | — | — |
-| 15 | Input 4 voltage | PV String 7 current | — | — | — | — | — | — |
-| 15 | Input 4 voltage | PV String 8 voltage | — | — | — | — | — | — |
-| 15 | Input 4 voltage | PV String 8 current | — | — | — | — | — | — |
-| 15 | Input 4 voltage | PV String 9 voltage | — | — | — | — | — | — |
-| 15 | Input 4 voltage | PV String 9 current | — | — | — | — | — | — |
-| 16 | Input 4 Amperage | PV String 10 voltage | — | — | — | — | — | — |
-| 16 | Input 4 Amperage | PV String 10 current | — | — | — | — | — | — |
-| 16 | Input 4 Amperage | PV String 11 voltage | — | — | — | — | — | — |
-| 16 | Input 4 Amperage | PV String 11 current | — | — | — | — | — | — |
-| 16 | Input 4 Amperage | PV String 12 voltage | — | — | — | — | — | — |
-| 16 | Input 4 Amperage | PV String 12 current | — | — | — | — | — | — |
-| 16 | Input 4 Amperage | PV String 13 voltage | — | — | — | — | — | — |
-| 16 | Input 4 Amperage | PV String 13 current | — | — | — | — | — | — |
-| 16 | Input 4 Amperage | PV String 14 voltage | — | — | — | — | — | — |
-| 16 | Input 4 Amperage | PV String 14 current | — | — | — | — | — | — |
-| 17 | Battery voltage | PV String 15 voltage | — | — | — | — | offgrid:battery_voltage | Battery voltage |
-| 17 | Battery voltage | PV String 15 current | — | — | — | — | offgrid:battery_voltage | Battery voltage |
-| 17 | Battery voltage | PV String 16 voltage | — | — | — | — | offgrid:battery_voltage | Battery voltage |
-| 17 | Battery voltage | PV String 16 current | — | — | — | — | offgrid:battery_voltage | Battery voltage |
-| 17 | Battery voltage | Bit 0~15: String 1~16 unmatch | — | — suggestive | — | — | offgrid:battery_voltage | Battery voltage |
-| 17 | Battery voltage | Bit 0~15: String 1~16 current u | — | — suggestive | — | — | offgrid:battery_voltage | Battery voltage |
-| 17 | Battery voltage | Bit 0~15: String 1~16 disconnec | — | — suggestive | — | — | offgrid:battery_voltage | Battery voltage |
-| 17 | Battery voltage | Bit 0:Output over voltage Bit 1: ISO fault Bit 2: BUS voltage abnormal Bit 3~15:reserved | — | — | — | — | offgrid:battery_voltage | Battery voltage |
-| 17 | Battery voltage | String Prompt Bit 0:String Unmatch Bit 1:Str Disconnect Bit 2:Str Current Unblance Bit 3~15:reserved | — | — | — | — | offgrid:battery_voltage | Battery voltage |
-| 17 | Battery voltage | PV Warning Value | — | — | — | — | offgrid:battery_voltage | Battery voltage |
-| 18 | Output 2 voltage | DSP 075 Warning Value | — | — | — | — | offgrid:soc | SOC |
-| 18 | Output 2 voltage | ult DSP 075 Fault Value | — | — | — | — | offgrid:soc | SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 1 | — | — | — | — | offgrid:soc | SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 2 | — | — | — | — | offgrid:soc | SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 3 | — | — | — | — | offgrid:soc | SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 4 | — | — | — | — | offgrid:soc | SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 5 | — | — | — | — | offgrid:soc | SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 6 | — | — | — | — | offgrid:soc | SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 7 | — | — | — | — | offgrid:soc | SOC |
-| 18 | Output 2 voltage | g DSP 067 Debug Data 8 | — | — | — | — | offgrid:soc | SOC |
-| 19 | Bus voltage | g DSP 075 Debug Data 1 | — | — | — | — | offgrid:bus_voltage | Bus voltage |
-| 19 | Bus voltage | g DSP 075 Debug Data 2 | — | — | — | — | offgrid:bus_voltage | Bus voltage |
-| 19 | Bus voltage | g DSP 075 Debug Data 3 | — | — | — | — | offgrid:bus_voltage | Bus voltage |
-| 19 | Bus voltage | g DSP 075 Debug Data 4 | — | — | — | — | offgrid:bus_voltage | Bus voltage |
-| 19 | Bus voltage | g DSP 075 Debug Data 5 | — | — | — | — | offgrid:bus_voltage | Bus voltage |
-| 19 | Bus voltage | g DSP 075 Debug Data 6 | — | — | — | — | offgrid:bus_voltage | Bus voltage |
-| 19 | Bus voltage | g DSP 075 Debug Data 7 | — | — | — | — | offgrid:bus_voltage | Bus voltage |
-| 19 | Bus voltage | g DSP 075 Debug Data 8 | — | — | — | — | offgrid:bus_voltage | Bus voltage |
-| 19 | Bus voltage | USBAging Test Ok Flag 0-1 | — | — | — | — | offgrid:bus_voltage | Bus voltage |
-| 19 | Bus voltage | Flash Erase Aging Ok Flag 0-1 | — | — | — | — | offgrid:bus_voltage | Bus voltage |
-| 20 | Grid voltage | PVISOValue | — | — | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | R DCI Curr | — | — | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | S DCI Curr | — | — | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | T DCI Curr | — | — | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | PIDBus Volt | — | — | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | GFCI Curr | — | — | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | SVG/APF Status+SVGAPFEqual Rat | — | — | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | R phase load side current for | — | — | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | S phase load side current for | — | — | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | T phase load side current for | — | — | — | — | offgrid:grid_voltage | Grid voltage |
-| 21 | AC frequency | R phase load side output reac power for SVG(High) | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | R phase load side output reac power for SVG(low) | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | S phase load side output reac power for SVG(High) | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | S phase load side output reac power for SVG(low) | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | T phase load side output reac power for SVG(High) | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | T phase load side output reac power for SVG(low) | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | R phase load side harmonic | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | S phase load side harmonic | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | T phase load side harmonic | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | R phase compensate reactive p for SVG(High) | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 22 | Output 1 voltage | R phase compensate reactive p for SVG(low) | — | — | — | — | offgrid:output_1_voltage | Output 1 voltage, Output voltage |
-| 22 | Output 1 voltage | S phase compensate reactive p for SVG(High) | — | — | — | — | offgrid:output_1_voltage | Output 1 voltage, Output voltage |
-| 22 | Output 1 voltage | S phase compensate reactive p for SVG(low) | — | — | — | — | offgrid:output_1_voltage | Output 1 voltage, Output voltage |
-| 22 | Output 1 voltage | T phase compensate reactive p for SVG(High) | — | — | — | — | offgrid:output_1_voltage | Output 1 voltage, Output voltage |
-| 22 | Output 1 voltage | T phase compensate reactive p for SVG(low) | — | — | — | — | offgrid:output_1_voltage | Output 1 voltage, Output voltage |
-| 22 | Output 1 voltage | R phase compensate harmonic f SVG | — | — | — | — | offgrid:output_1_voltage | Output 1 voltage, Output voltage |
-| 22 | Output 1 voltage | S phase compensate harmonic f SVG | — | — | — | — | offgrid:output_1_voltage | Output 1 voltage, Output voltage |
-| 22 | Output 1 voltage | T phase compensate harmonic f SVG | — | — | — | — | offgrid:output_1_voltage | Output 1 voltage, Output voltage |
-| 22 | Output 1 voltage | RS 232 Aging Test Ok Flag | — | — | — | — | offgrid:output_1_voltage | Output 1 voltage, Output voltage |
-| 22 | Output 1 voltage | Bit 0: Fan 1 fault bit Bit 1: Fan 2 fault bit Bit 2: Fan 3 fault bit Bit 3: Fan 4 fault bit Bit 4-7: Reserved | — | — | — | — | offgrid:output_1_voltage | Output 1 voltage, Output voltage |
-| 23 | Input 6 voltage | Output apparent power H | — | — | — | — | offgrid:output_frequency | Output frequency |
-| 23 | Input 6 voltage | Output apparent power L | — | — | — | — | offgrid:output_frequency | Output frequency |
-| 23 | Input 6 voltage | Real Output Reactive Power H | — | — | — | — | offgrid:output_frequency | Output frequency |
-| 23 | Input 6 voltage | Real Output Reactive Power L | — | — | — | — | offgrid:output_frequency | Output frequency |
-| 23 | Input 6 voltage | Nominal Output Reactive Power | — | — | — | — | offgrid:output_frequency | Output frequency |
-| 23 | Input 6 voltage | Nominal Output Reactive Power | — | — | — | — | offgrid:output_frequency | Output frequency |
-| 23 | Input 6 voltage | Reactive power generation | — | — | — | — | offgrid:output_frequency | Output frequency |
-| 23 | Input 6 voltage | Reactive power generation | — | — | — | — | offgrid:output_frequency | Output frequency |
-| 23 | Input 6 voltage | 0:Waiting 1:Self-check state 2:Detect pull arc state 3:Fault 4:Update | — | — | — | — | offgrid:output_frequency | Output frequency |
-| 23 | Input 6 voltage | Present FFTValue [CHANNEL_A] | — | — | — | — | offgrid:output_frequency | Output frequency |
-| 24 | Input 6 Amperage | Present FFTValue [CHANNEL_B] | — | — | — | — | offgrid:output_dc_voltage | Output DC voltage |
-| 24 | Input 6 Amperage | ug DSP 067 Debug Data 1 | — | — | — | — | offgrid:output_dc_voltage | Output DC voltage |
-| 24 | Input 6 Amperage | ug DSP 067 Debug Data 2 | — | — | — | — | offgrid:output_dc_voltage | Output DC voltage |
-| 24 | Input 6 Amperage | ug DSP 067 Debug Data 3 | — | — | — | — | offgrid:output_dc_voltage | Output DC voltage |
-| 24 | Input 6 Amperage | g DSP 067 Debug Data 4 | — | — | — | — | offgrid:output_dc_voltage | Output DC voltage |
-| 24 | Input 6 Amperage | g DSP 067 Debug Data 5 | — | — | — | — | offgrid:output_dc_voltage | Output DC voltage |
-| 24 | Input 6 Amperage | g DSP 067 Debug Data 6 | — | — | — | — | offgrid:output_dc_voltage | Output DC voltage |
-| 24 | Input 6 Amperage | g DSP 067 Debug Data 7 | — | — | — | — | offgrid:output_dc_voltage | Output DC voltage |
-| 24 | Input 6 Amperage | g DSP 067 Debug Data 8 | — | — | — | — | offgrid:output_dc_voltage | Output DC voltage |
-| 24 | Input 6 Amperage | — | — | — | — | — | offgrid:output_dc_voltage | Output DC voltage |
-| 87 | Input 8 energy today | PV 9 voltage | — | — | — | — | — | — |
-| 87 | Input 8 energy today | PV 9 Input current | — | — | — | — | — | — |
-| 87 | Input 8 energy today | PV 9 input power (High) | — | — | — | — | — | — |
-| 87 | Input 8 energy today | PV 9 input power (Low) | — | — | — | — | — | — |
-| 87 | Input 8 energy today | PV 10 voltage | — | — | — | — | — | — |
-| 88 | 0 PV 10 Curr | PV 10 Input current | — | — | — | — | — | — |
-| 88 | 1 Ppv 10 H | PV 10 input power (High) | — | — | — | — | — | — |
-| 88 | 2 Ppv 10 L | PV 10 input power (Low) | — | — | — | — | — | — |
-| 88 | 3 Vpv 11 | PV 11 voltage | — | — | — | — | — | — |
-| 88 | 4 PV 11 Curr | PV 11 Input current | — | — | — | — | — | — |
-| 88 | 5 Ppv 11 H | PV 11 input power (High) | — | — | — | — | — | — |
-| 88 | 6 Ppv 11 L | PV 11 input power (Low) | — | — | — | — | — | — |
-| 88 | 7 Vpv 12 | PV 12 voltage | — | — | — | — | — | — |
-| 88 | 8 PV 12 Curr | PV 12 Input current | — | — | — | — | — | — |
-| 88 | 9 Ppv 12 H | PV 12 input power (High) | — | — | — | — | — | — |
-| 89 | Input 8 total energy | PV 12 input power (Low) | — | — | — | — | — | — |
-| 89 | Input 8 total energy | PV 13 voltage | — | — | — | — | — | — |
-| 89 | Input 8 total energy | PV 13 Input current | — | — | — | — | — | — |
-| 89 | Input 8 total energy | PV 13 input power (High) | — | — | — | — | — | — |
-| 89 | Input 8 total energy | PV 13 input power (Low) | — | — | — | — | — | — |
-| 89 | Input 8 total energy | PV 14 voltage | — | — | — | — | — | — |
-| 89 | Input 8 total energy | PV 14 Input current | — | — | — | — | — | — |
-| 89 | Input 8 total energy | PV 14 input power (High) | — | — | — | — | — | — |
-| 89 | Input 8 total energy | PV 14 input power (Low) | — | — | — | — | — | — |
-| 89 | Input 8 total energy | PV 15 voltage | — | — | — | — | — | — |
-| 90 | 0 PV 15 Curr | PV 15 Input current | — | — | — | — | — | — |
-| 90 | 1 Ppv 15 H | PV 15 input power (High) | — | — | — | — | — | — |
-| 90 | 2 Ppv 15 L | PV 15 input power (Low) | — | — | — | — | — | — |
-| 90 | 3 Vpv 16 | PV 16 voltage | — | — | — | — | — | — |
-| 90 | 4 PV 16 Curr | PV 16 Input current | — | — | — | — | — | — |
-| 90 | 5 Ppv 16 H | PV 16 input power (High) | — | — | — | — | — | — |
-| 90 | 6 Ppv 16 L | PV 16 input power (Low) | — | — | — | — | — | — |
-| 90 | 7 Epv 9_today H | PV 9 energy today (High) | — | — | — | — | — | — |
-| 90 | 8 Epv 9_today L | PV 9 energy today (Low) | — | — | — | — | — | — |
-| 90 | 9 Epv 9_total H | PV 9 energy total (High) | — | — | — | — | — | — |
-| 91 | Total energy input | PV 9 energy total (Low) | — | — | — | — | — | — |
-| 91 | Total energy input | PV 10 energy today (High) | — | — | — | — | — | — |
-| 91 | Total energy input | PV 10 energy today (Low) | — | — | — | — | — | — |
-| 91 | Total energy input | PV 10 energy total (High) | — | — | — | — | — | — |
-| 91 | Total energy input | PV 10 energy total (Low) | — | — | — | — | — | — |
-| 91 | Total energy input | PV 11 energy today (High) | — | — | — | — | — | — |
-| 91 | Total energy input | PV 11 energy today (Low) | — | — | — | — | — | — |
-| 91 | Total energy input | PV 11 energy total (High) | — | — | — | — | — | — |
-| 91 | Total energy input | PV 11 energy total (Low) | — | — | — | — | — | — |
-| 91 | Total energy input | PV 12 energy today (High) | — | — | — | — | — | — |
-| 92 | 0 Epv 12_today L | PV 12 energy today (Low) | — | — | — | — | — | — |
-| 92 | 1 Epv 12_total H | PV 12 energy total (High) | — | — | — | — | — | — |
-| 92 | 2 Epv 12_total L | PV 12 energy total (Low) | — | — | — | — | — | — |
-| 92 | 3 Epv 13_today H | PV 13 energy today (High) | — | — | — | — | — | — |
-| 92 | 4 Epv 13_today L | PV 13 energy today (Low) | — | — | — | — | — | — |
-| 92 | 5 Epv 13_total H | PV 13 energy total (High) | — | — | — | — | — | — |
-| 92 | 6 Epv 13_total L | PV 13 energy total (Low) | — | — | — | — | — | — |
-| 92 | 7 Epv 14_today H | PV 14 energy today (High) | — | — | — | — | — | — |
-| 92 | 8 Epv 14_today L | PV 14 energy today (Low) | — | — | — | — | — | — |
-| 92 | 9 Epv 14_total H | PV 14 energy total (High) | — | — | — | — | — | — |
-| 93 | Temperature | PV 14 energy total (Low) | — | — | — | — | — | — |
-| 93 | Temperature | PV 15 energy today (High) | — | — | — | — | — | — |
-| 93 | Temperature | PV 15 energy today (Low) | — | — | — | — | — | — |
-| 93 | Temperature | PV 15 energy total (High) | — | — | — | — | — | — |
-| 93 | Temperature | PV 15 energy total (Low) | — | — | — | — | — | — |
-| 93 | Temperature | PV 16 energy today (High) | — | — | — | — | — | — |
-| 93 | Temperature | PV 16 energy today (Low) | — | — | — | — | — | — |
-| 93 | Temperature | PV 16 energy total (High) | — | — | — | — | — | — |
-| 93 | Temperature | PV 16 energy total (Low) | — | — | — | — | — | — |
-| 93 | Temperature | PID PV 9 PE Volt/ Flyspan volta (MAX HV) | — | — | — | — | — | — |
-| 94 | Intelligent Power Management temperature | PID PV 9 PE Current | — | — | — | — | — | — |
-| 94 | Intelligent Power Management temperature | + PID PV 10 PE/ Flyspan voltage ( HV) | — | — | — | — | — | — |
-| 94 | Intelligent Power Management temperature | 0+ PID PV 10 PE Current | — | — | — | — | — | — |
-| 94 | Intelligent Power Management temperature | 1+ PID PV 11 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | — | — |
-| 94 | Intelligent Power Management temperature | 1+ PID PV 11 PE Current | — | — | — | — | — | — |
-| 94 | Intelligent Power Management temperature | 2+ PID PV 12 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | — | — |
-| 94 | Intelligent Power Management temperature | 2+ PID PV 12 PE Current | — | — | — | — | — | — |
-| 94 | Intelligent Power Management temperature | 3+ PID PV 13 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | — | — |
-| 94 | Intelligent Power Management temperature | 3+ PID PV 13 PE Current | — | — | — | — | — | — |
-| 94 | Intelligent Power Management temperature | 4+ PID PV 14 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | — | — |
-| 95 | Boost temperature | 4+ PID PV 14 PE Current | — | — | — | — | — | — |
-| 95 | Boost temperature | 5+ PID PV 15 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | — | — |
-| 95 | Boost temperature | 5+ PID PV 15 PE Current | — | — | — | — | — | — |
-| 95 | Boost temperature | 6+ PID PV 16 PE Volt/ Flyspan volt (MAX HV) | — | — | — | — | — | — |
-| 95 | Boost temperature | 6+ PID PV 16 PE Current | — | — | — | — | — | — |
-| 95 | Boost temperature | PV String 17 voltage | — | — | — | — | — | — |
-| 95 | Boost temperature | PV String 17 Current | — | — | — | — | — | — |
-| 95 | Boost temperature | PV String 18 voltage | — | — | — | — | — | — |
-| 95 | Boost temperature | PV String 18 Current | — | — | — | — | — | — |
-| 95 | Boost temperature | PV String 19 voltage | — | — | — | — | — | — |
-| 96 | 0 Curr _String 19 | PV String 19 Current | — | — | — | — | — | — |
-| 96 | 1 V _String 20 | PV String 20 voltage | — | — | — | — | — | — |
-| 96 | 2 Curr _String 20 | PV String 20 Current | — | — | — | — | — | — |
-| 96 | 3 V _String 21 | PV String 21 voltage | — | — | — | — | — | — |
-| 96 | 4 Curr _String 21 | PV String 21 Current | — | — | — | — | — | — |
-| 96 | 5 V _String 22 | PV String 22 voltage | — | — | — | — | — | — |
-| 96 | 6 Curr _String 22 | PV String 22 Current | — | — | — | — | — | — |
-| 96 | 7 V _String 23 | PV String 23 voltage | — | — | — | — | — | — |
-| 96 | 8 Curr _String 23 | PV String 23 Current | — | — | — | — | — | — |
-| 96 | 9 V _String 24 | PV String 24 voltage | — | — | — | — | — | — |
-| 97 | 0 Curr _String 24 | PV String 24 Current | — | — 0.1 A | — | — | — | — |
-| 97 | 1 V _String 25 | PV String 25 voltage | — | — 0.1 V | — | — | — | — |
-| 97 | 2 Curr _String 25 | PV String 25 Current | — | — 0.1 A | — | — | — | — |
-| 97 | 3 V _String 26 | PV String 26 voltage | — | — 0.1 V | — | — | — | — |
-| 97 | 4 Curr _String 26 | PV String 26 Current | — | — 0.1 A | — | — | — | — |
-| 97 | 5 V _String 27 | PV String 27 voltage | — | — 0.1 V | — | — | — | — |
-| 97 | 6 Curr _String 27 | PV String 27 Current | — | — 0.1 A | — | — | — | — |
-| 97 | 7 V _String 28 | PV String 28 voltage | — | — 0.1 V | — | — | — | — |
-| 97 | 8 Curr _String 28 | PV String 28 Current | — | — 0.1 A | — | — | — | — |
-| 97 | 9 V _String 29 | PV String 29 voltage | — | — 0.1 V | — | — | — | — |
-| 98 | P-bus voltage | PV String 29 Current | — | — 0.1 A | — | — | — | — |
-| 98 | P-bus voltage | PV String 30 voltage | — | — 0.1 V | — | — | — | — |
-| 98 | P-bus voltage | PV String 30 Current | — | — 0.1 A | — | — | — | — |
-| 98 | P-bus voltage | PV String 31 voltage | — | — 0.1 V | — | — | — | — |
-| 98 | P-bus voltage | PV String 31 Current | — | — 0.1 A | — | — | — | — |
-| 98 | P-bus voltage | PV String 32 voltage | — | — 0.1 V | — | — | — | — |
-| 98 | P-bus voltage | PV String 32 Current | — | — 0.1 A | — | — | — | — |
-| 98 | P-bus voltage | Bit 0~15: String 17~32 unmatch | — | — | — | — | — | — |
-| 98 | P-bus voltage | Bit 0~15:String 17~32 unblance | — | — | — | — | — | — |
-| 98 | P-bus voltage | Bit 0~15: String 17~32 disconn | — | — | — | — | — | — |
-| 99 | N-bus voltage | PV Warning Value (PV 9-PV 16) Contains PV 9~16 abnormal, 和 Boost 9~16 Drive anomalies | — | — | — | — | — | — |
-| 99 | N-bus voltage | string 1~string 16 abnormal | — | — | — | — | — | — |
-| 99 | N-bus voltage | string 17~string 32 abnormal | — | — | — | — | — | — |
-| 99 | N-bus voltage | M 3 to DSP system command | — | — system command | — | — | — | — |
-| 10 | 00. uw Sys Work Mode | System work mode | — | — Theworkingmode displayed by the monitoring to the customer is: 0 x 00: waiting module 0 x 01: Self-test mode, 0 x 03:fault module 0 x 04:flash odule x 05|0 x 06|0 x 07|0 08:normal odule | — | — | — | — |
-| 10 | 01. Systemfault word 0 | System fault word 0 | — | — lease refer to hefault escription of ybrid | — | — | — | — |
-| 10 | 02. Systemfault word 1 | System fault word 1 | — | — | — | — | — | — |
-| 10 | 03. Systemfault word 2 | System fault word 2 | — | — | — | — | — | — |
-| 10 | 04. Systemfault word 3 | System fault word 3 | — | — | — | — | — | — |
-| 10 | 05. Systemfault word 4 | System fault word 4 | — | — | — | — | — | — |
-| 10 | 06. Systemfault word 5 | System fault word 5 | — | — | — | — | — | — |
-| 10 | 07. Systemfault word 6 | System fault word 6 | — | — | — | — | — | — |
-| 10 | 08. Systemfault word 7 | System fault word 7 | — | — | — | — | — | — |
-| 10 | 09. Pdischarge 1 H | Discharge power(high) | — | — | — | — | — | — |
-| 10 | 10. Pdischarge 1 L | Discharge power (low) | — | — | — | — | — | — |
-| 10 | 11. Pcharge 1 H | Charge power(high) | — | — | — | — | — | — |
-| 10 | 12. Pcharge 1 L | Charge power (low) | — | — | — | — | — | — |
-| 10 | 13. Vbat | Battery voltage | — | — | — | — | — | — |
-| 10 | 14. SOC | State of charge Capacity | — | — ith/leadacid | — | — | — | — |
-| 10 | 15. Pactouser R | H AC power to user H | — | — | — | — | — | — |
-| 10 | 16. Pactouser R | L AC power to user L | — | — | — | — | — | — |
-| 10 | 17. Pactouser S | H Pactouser S H | — | — | — | — | — | — |
-| 10 | 18. Pactouser S | L Pactouser S L | — | — | — | — | — | — |
-| 10 | 19. Pactouser T | H Pactouser T H | — | — | — | — | — | — |
-| 10 | 20. Pactouser T | L Pactouser T H | — | — | — | — | — | — |
-| 10 | 21. Pactouser Total H | AC power to user total H | — | — | — | — | — | — |
-| 10 | 22. Pactouser Total L | AC power to user total L | — | — | — | — | — | — |
-| 10 | 23. Pac to grid R H | AC power to grid H | — | — c output | — | — | — | — |
-| 10 | 24. Pac to grid R L | AC power to grid L | — | — | — | — | — | — |
-| 10 | 25. Pactogrid S H | — | — | — | — | — | — | — |
-| 10 | 26. Pactogrid S L | — | — | — | — | — | — | — |
-| 10 | 27. Pactogrid T H | — | — | — | — | — | — | — |
-| 10 | 28. Pactogrid T L | — | — | — | — | — | — | — |
-| 10 | 29. Pactogrid total H | AC power to grid total H | — | — | — | — | — | — |
-| 10 | 30. Pactogrid total L | AC power to grid total L | — | — | — | — | — | — |
-| 10 | 31. PLocal Load R | H INV power to local load H | — | — | — | — | — | — |
-| 10 | 32. PLocal Load R | L INV power to local load L | — | — | — | — | — | — |
-| 10 | 33. PLocal Load S | H | — | — | — | — | — | — |
-| 10 | 34. PLocal Load S | L | — | — | — | — | — | — |
-| 10 | 35. PLocal Load T H | — | — | — | — | — | — | — |
-| 10 | 36. PLocal Load T L | — | — | — | — | — | — | — |
-| 10 | 37. PLocal Load total | H INV power to local load tot | — | — | — | — | — | — |
-| 10 | 38. PLocal Load total | L INV power to local load tot L | — | — | — | — | — | — |
-| 10 | 39. IPM 2 Temperature | REC Temperature | — | — | — | — | — | — |
-| 10 | 40. Battery 2 Temperature | Battery Temperature | — | — ithium p | — | — | — | — |
-| 10 | 41. SP DSP Status | SP state | — | — | — | — | — | — |
-| 10 | 42. SP Bus Volt | SP BUS 2 Volt | — | — | — | — | — | — |
-| 10 | 43 | — | — | — | — | — | — | — |
-| 10 | 44. Etouser_today H | Energy to user today high | — | — | — | — | — | — |
-| 10 | 45. Etouser_today L | Energy to user today low | — | — | — | — | — | — |
-| 10 | 46. Etouser_total H | Energy to user total high | — | — | — | — | — | — |
-| 10 | 47. Etouser_ total L | Energy to user total high | — | — | — | — | — | — |
-| 10 | 48. Etogrid_today H | Energy to grid today high | — | — | — | — | — | — |
-| 10 | 49. Etogrid _today L | Energy to grid today low | — | — | — | — | — | — |
-| 10 | 50. Etogrid _total H | Energy to grid total high | — | — | — | — | — | — |
-| 10 | 51. Etogrid _ total L | Energy to grid total high | — | — | — | — | — | — |
-| 10 | 52. Edischarge 1_toda y H | Discharge energy 1 today | — | — | — | — | — | — |
-| 10 | 53. Edischarge 1_toda y L | Discharge energy 1 today | — | — | — | — | — | — |
-| 10 | 54. Edischarge 1_total H | Total discharge energy 1 (high) | — | — | — | — | — | — |
-| 10 | 55. Edischarge 1_total L | Total discharge energy 1 (low) | — | — | — | — | — | — |
-| 10 | 56. Echarge 1_today H | Charge 1 energy today | — | — | — | — | — | — |
-| 10 | 57. Echarge 1_today L | Charge 1 energy today | — | — | — | — | — | — |
-| 10 | 58. Echarge 1_total H | Charge 1 energy total | — | — | — | — | — | — |
-| 10 | 59. Echarge 1_total L | Charge 1 energy total | — | — | — | — | — | — |
-| 10 | 60. ELocal Load_Today H | Local load energy today | — | — | — | — | — | — |
-| 10 | 61. ELocal Load_Today L | Local load energy today | — | — | — | — | — | — |
-| 10 | 62. ELocal Load_Total H | Local load energy total | — | — | — | — | — | — |
-| 10 | 63. ELocal Load_Total L | Local load energy total | — | — | — | — | — | — |
-| 10 | 64. dw Export Limit Ap parent Power | Export Limit Apparent Power H | — | — rent Power | — | — | — | — |
-| 10 | 65. dw Export Limit Ap parent Power | Export Limit Apparent Power L | — | — rent Power | — | — | — | — |
-| 10 | 66. / | / | — | — rved | — | — | — | — |
-| 10 | 67. EPS Fac | UPSfrequency | — | — | — | — | — | — |
-| 10 | 68. EPS Vac 1 | UPS phase R output voltage | — | — | — | — | — | — |
-| 10 | 69. EPS Iac 1 | UPS phase R output current | — | — | — | — | — | — |
-| 10 | 70. EPS Pac 1 H | UPS phase R output power (H) | — | — | — | — | — | — |
-| 10 | 71. EPS Pac 1 L | UPS phase R output power (L) | — | — | — | — | — | — |
-| 10 | 72. EPS Vac 2 | UPS phase S output voltage | — | — | — | — | — | — |
-| 10 | 73. EPS Iac 2 | UPS phase S output current | — | — se | — | — | — | — |
-| 10 | 74. EPS Pac 2 H | UPS phase S output power (H) | — | — | — | — | — | — |
-| 10 | 75. EPS Pac 2 L | UPS phase S output power (L) | — | — | — | — | — | — |
-| 10 | 76. EPS Vac 3 | UPS phase T output voltage | — | — | — | — | — | — |
-| 10 | 77. EPS Iac 3 | UPS phase T output current | — | — se | — | — | — | — |
-| 10 | 78. EPS Pac 3 H | UPS phase T output power (H) | — | — | — | — | — | — |
-| 10 | 79. EPS Pac 3 L | UPS phase T output power (L) | — | — | — | — | — | — |
-| 10 | 80. Loadpercent | Load percent of UPS ouput | — | — | — | — | — | — |
-| 10 | 81. PF | Power factor | — | — ary Value+1 | — | — | — | — |
-| 10 | 82. BMS_Status Old | Status Old from BMS | — | — | — | — | — | — |
-| 10 | 83. BMS_Status | Status from BMS | — | — | — | — | — | — |
-| 10 | 84. BMS_Error Old | Error info Old from BMS | — | — | — | — | — | — |
-| 10 | 85. BMS_Error | Errorinfomation from BMS | — | — | — | — | — | — |
-| 10 | 86. BMS_SOC BMS_Battery Vol | SOC from BMS Battery voltage from BMS | — | — H 6 K H 6 K | — | — | — | — |
-| 10 | 87. t BMS_Battery Cur | Battery current from BMS | — | — | — | — | — | — |
-| 10 | 88. r BMS_Battery Te | Battery temperature from BMS | — | — | — | — | — | — |
-| 10 | 89. mp BMS_Max Curr | Max. charge/discharge current | — | — | — | — | — | — |
-| 10 | 90. | from BMS (pylon) | — | — | — | — | — | — |
-| 10 | 91. BMS_Gauge RM | Gauge RM from BMS | — | — | — | — | — | — |
-| 10 | 92. BMS_Gauge FCC | Gauge FCC from BMS | — | — | — | — | — | — |
-| 10 | 93. BMS_FW | — | — | — | — | — | — | — |
-| 10 | 94. BMS_Delta Volt | Delta V from BMS | — | — | — | — | — | — |
-| 10 | 95. BMS_Cycle Cnt | Cycle Count from BMS | — | — | — | — | — | — |
-| 10 | 96. BMS_SOH BMS_Constant V | SOH from BMS CV voltage from BMS | — | — | — | — | — | — |
-| 10 | 97. olt BMS_Warn Info O | Warning info old from BMS | — | — | — | — | — | — |
-| 10 | 98. ld | — | — | — | — | — | — | — |
-| 10 | 99. BMS_Warn Info BMS_Gauge ICCu | Warning info from BMS Gauge IC current from BMS | — | — | — | — | — | — |
-| 11 | Input 3 voltage | MCU Software version from BMS | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Gauge Version from BMS | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Gauge FR Version L 16 from BMS | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Gauge FR Version H 16 from BMS | — | — | — | — | — | — |
-| 11 | Input 3 voltage | — | — | — | — | — | — | — |
-| 11 | Input 3 voltage | BMSInformation from BMS | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Pack Information from BMS | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Using Cap from BMS | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Maximum single battery voltage | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Lowest single battery voltage | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Battery parallel number | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Number of batteries Max Volt Cell No | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Min Volt Cell No | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Max Tempr Cell_10 T | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Min Tempr Cell_10 T | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Max Volt Tempr Cell No | — | — | — | — | — | — |
-| 11 | Input 3 voltage | — | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Min Volt Tempr Cell No | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Faulty Battery Address | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Parallel maximum SOC | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Parallel minimum SOC Battery Protection 2 | — | — CAN ID: 0 x 323 | — | — | — | — |
-| 11 | Input 3 voltage | Battery Protection 3 | — | — Byte 4~5 CAN ID: 0 x 323 | — | — | — | — |
-| 11 | Input 3 voltage | Battery Warn 2 | — | — Byte 6 CAN ID: 0 x 323 | — | — | — | — |
-| 11 | Input 3 voltage | — | — | — Byte 7 | — | — | — | — |
-| 11 | Input 3 voltage | AC Charge Energy today | — | — Energy today | — | — | — | — |
-| 11 | Input 3 voltage | AC Charge Energy today | — | — | — | — | — | — |
-| 11 | Input 3 voltage | — | — | — Energy total | — | — | — | — |
-| 11 | Input 3 voltage | — | — | — | — | — | — | — |
-| 11 | Input 3 voltage | AC Charge Power | — | — | — | — | — | — |
-| 11 | Input 3 voltage | AC Charge Power | — | — | — | — | — | — |
-| 11 | Input 3 voltage | uw Grid Power_70_Adj EE_SP | — | — | — | — | — | — |
-| 11 | Input 3 voltage | tra inverte AC Power to grid gh | — | — SPA used | — | — | — | — |
-| 11 | Input 3 voltage | trainverte AC Power to grid Low | — | — SPA used | — | — | — | — |
-| 11 | Input 3 voltage | Extra inverter Power TOUser_Extr today (high) | — | — SPA used | — | — | — | — |
-| 11 | Input 3 voltage | Extra inverter Power TOUser_Extr today (low) | — | — SPA used | — | — | — | — |
-| 11 | Input 3 voltage | Extra inverter Power TOUser_Extr total(high) | — | — SPA used | — | — | — | — |
-| 11 | Input 3 voltage | Extra inverter Power TOUser_Extr total(low) | — | — SPA used | — | — | — | — |
-| 11 | Input 3 voltage | System electric energy today H | — | — SPA used System electric energy today H | — | — | — | — |
-| 11 | Input 3 voltage | stem electric energy today L | — | — d electric today L | — | — | — | — |
-| 11 | Input 3 voltage | System electric energy total H | — | — d electric total H | — | — | — | — |
-| 11 | Input 3 voltage | System electric energy total L | — | — d electric total L | — | — | — | — |
-| 11 | Input 3 voltage | self electric energy today H | — | — electric today H | — | — | — | — |
-| 11 | Input 3 voltage | self electric energy today L | — | — electric today L | — | — | — | — |
-| 11 | Input 3 voltage | self electric energy total H | — | — electric total H | — | — | — | — |
-| 11 | Input 3 voltage | self electric energy total L | — | — electric total L | — | — | — | — |
-| 11 | Input 3 voltage | System power H | — | — power H | — | — | — | — |
-| 11 | Input 3 voltage | System power L | — | — power L | — | — | — | — |
-| 11 | Input 3 voltage | self power H | — | — wer H | — | — | — | — |
-| 11 | Input 3 voltage | self power L | — | — wer L | — | — | — | — |
-| 11 | Input 3 voltage | PV electric energy today H | — | — | — | — | — | — |
-| 11 | Input 3 voltage | PV electric energy today L | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Discharge power pack number | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Cumulative discharge power high 16-bit byte | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Cumulative discharge power low 16-bit byte | — | — | — | — | — | — |
-| 11 | Input 3 voltage | charge power pack serial number | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Cumulative charge power high R 16-bit byte | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Cumulative charge power low R 16-bit byte | — | — | — | — | — | — |
-| 11 | Input 3 voltage | First Batt Fault Sn | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Second Batt Fault Sn | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Third Batt Fault Sn | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Fourth Batt Fault Sn | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Battery history fault code 1 | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Battery history fault code 2 | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Battery history fault code 3 | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Battery history fault code 4 | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Battery history fault code 5 | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Battery history fault code 6 | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Battery history fault code 7 | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Battery history fault code 8 | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Number of battery codes PACK number + BIC forward and reverse codes | — | — | — | — | — | — |
-| 11 | Input 3 voltage | — | — | — | — | — | — | — |
-| 11 | Input 3 voltage | Intelligent reading is used to identify software compatibility features | — | — rgy; rgy | — | — | — | — |
-| 1 | Input 1 voltage | Maximum cell voltage | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Minimum cell voltage | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Number of Battery modules | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Total number of cells | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Max Volt Cell No | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Min Volt Cell No | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Max Tempr Cell_10 T | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Min Tempr Cell_10 T | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Max Tempr Cell No | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Min Tempr Cell No | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Fault Pack ID | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Parallel maximum SOC | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Parallel minimum SOC | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Bat Protect 1 Add | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Bat Protect 2 Add | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | Bat Warn 1 Add | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | BMS_Highest Soft Version | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | BMS_Hardware Version | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 1 | Input 1 voltage | BMS_Request Type | — | — | — | — | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
-| 12 | Input 3 Amperage | Success sign of key detection before aging | — | — 1:Finished test 0: test not completed | — | — | — | — |
-| 12 | Input 3 Amperage | / | — | — reversed | — | — | — | — |
-| 20 | Grid voltage | Inverter run state | — | — SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Output power (high) | — | — 1 W SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Output power (low) | — | — 1 W SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Grid frequency | — | — 01 Hz SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Three/single phase grid voltage | — | — 1 V SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Three/single phase grid output | — | — 1 A SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Three/single phase grid output VA (high) | — | — 1 VA SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Three/single phase grid output VA(low) | — | — 1 VA SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Today generate energy (high) | — | — 1 k WH SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Today generate energy (low) | — | — 1 k WH SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Total generate energy (high) | — | — WH SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Total generate energy (low) | — | — WH SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Work time total (high) | — | — SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Work time total (low) | — | — SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Inverter temperature | — | — SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | The inside IPM in inverter Temp | — | — SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Boost temperature | — | — SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | — | — | — reserved | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | Bat Volt_DSP | — | — Bat Volt(DSP) | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | P Bus inside Voltage | — | — SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 20 | Grid voltage | N Bus inside Voltage | — | — SPA | — | — | offgrid:grid_voltage | Grid voltage |
-| 21 | AC frequency | / | — | — Remote setup enable | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | / | — | — Remotely set power | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | Extra inverte AC Power to grid | — | — SPA used | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | Extrainverte AC Power to grid L | — | — SPA used | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | Extra inverter Power TOUser_Extr today (high) | — | — Wh SPA used | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | Extra inverter Power TOUser_Extr today (low) | — | — Wh SPA used | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | Extra inverter Power TOUser_Extratotal(high) | — | — Wh SPA used | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | Extra inverter Power TOUser_Extr total(low) | — | — Wh SPA used | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | System electric energy today H | — | — Wh SPA used System electric energy today H | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | stem electric energy today L | — | — Wh SPA used System electric energy today L | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | System electric energy total H | — | — Wh SPA used System c total | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | System electric energy total L | — | — d c total | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | ACCharge energy today | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | ACCharge energy today | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | ACCharge energy total | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | ACCharge energy total | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | Grid power to local load | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | Grid power to local load | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | 0:Load First 1:Battery First 2:Grid First | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | 0:Lead-acid 1:Lithium battery | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | Aging mode | — | — | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 21 | AC frequency | — | — | — d | — | — | offgrid:grid_frequency | AC frequency, Grid frequency |
-| 3 | Input 1 Wattage | 2: Reserved 3:Sys Fault module 4: Flash module 5:PVBATOnline module: 6:Bat Online module 7:PVOffline Mode 8:Bat Offline Mode The lower 8 bits indicate the m status (web page display) 0: Standby Status; 1: Normal Status; 3: Fault Status 4:Flash Status; | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV total power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 1 voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 1 input current | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 1 power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 2 voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 2 input current | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 2 power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 3 voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 3 input current | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 3 power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 4 voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 4 input current | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 4 power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | System output power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | reactive power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Output power | — | — ut | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Grid frequency | — | — r | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three/single phase grid voltage | — | — uency e/single | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — e grid age | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three/single phase grid output | — | — e/single rid | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three/single phase grid output VA | — | — ingle rid | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three phase grid voltage | — | — watt hase | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three phase grid output current | — | — ltage hase | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — tput | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three phase grid output power | — | — hase tput | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three phase grid voltage | — | — hase | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three phase grid output current | — | — ltage hase | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — tput | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three phase grid output power | — | — hase tput | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three phase grid voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three phase grid voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Three phase grid voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total forward power | — | — orward | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total reverse power | — | — everse | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total load power | — | — load | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Work time total | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Today generate energy | — | — e | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total generate energy | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — e | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV energy total | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 1 energy today | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 1 energy total | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 2 energy today | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 2 energy total | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 3 energy today | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 3 energy total | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Today energy to user | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total energy to user | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Today energy to grid | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total energy to grid | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Today energy of user load | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total energy of user load | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 4 energy today | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV 4 energy total | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV energy today | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Derating Mode | — | — h | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — k T l A i | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | PV ISO value | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | R DCI Curr | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | S DCI Curr | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | T DCI Curr | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | GFCI Curr | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | total bus voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Inverter temperature | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | The inside IPM in inverter temp | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Boost temperature | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Reserved | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Commmunication broad temperatur | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | P Bus inside Voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | N Bus inside Voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Inverter output PF now | — | — 000 | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Real Output power Percent | — | — 0 | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Output Maxpower Limited | — | — ut ower | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Inverter standby flag | — | — ted:turn off r;:PV Low;:AC | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — /Freq of scope; ~bit 7: rved | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Inverter fault maincode | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Inverter Warning maincode | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Inverter fault subcode | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Inverter Warning subcode | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Present FFTValue [CHANNEL_A] | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | AFCI Status | — | — waiting e lf-check Detection | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | AFCI Strength[CHANNEL_A] | — | — arcing e ult state update e | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | AFCI Self Check[CHANNEL_A] | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | inv start delay time | — | — lay | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BDC connect state | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Current status of Dry Contact | — | — of | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | self-use power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | System energy today | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Today discharge energy | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total discharge energy | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Charge energy today | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Charge energy total | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Today energy of AC charge | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total energy of AC charge | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total energy of system outpu | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Today energy of Self output | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total energy of Self output | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Word Mode | — | — ad First | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — ery Firs id First | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | UPS frequency | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | UPS phase R output voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | UPS phase R output current | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | UPS phase R output power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | UPS phase S output voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | UPS phase S output current | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | UPS phase S output power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | UPS phase T output voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | UPS phase T output current | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | UPS phase T output power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | UPS output power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Load percent of UPS ouput | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Power factor | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | DC voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Whether to parse BDC data separ | — | — on't need | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BDCDerating Mode: 0: Normal, unrestricted 1:Standby or fault | — | — ed | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | 2:Maximum battery current limit (discharge) 3:Battery discharge Enable (Dis 4:High bus discharge derating (discharge) 5:High temperature discharge derating (discharge) 6:System warning No discharge (discharge) 7-15 Reserved (Discharge) 16:Maximum charging current of battery (charging) 17:High Temperature (LLC and Buckboost) (Charging) 18:Final soft charge 19:SOC setting limits (charging 20:Battery low temperature (cha 21:High bus voltage (charging) 22:Battery SOC (charging) 23: Need to charge (charge) 24: System warning not charging (charging) 25-29:Reserve (charge) System work State and mode The upper 8 bits indicate the mode; 0:No charge and discharge; 1:charge; 2:Discharge; | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | The lower 8 bits represent the 0: Standby Status; 1: Normal Status; 2: Fault Status 3:Flash Status; | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Storge device fault code | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Storge device warning code | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Battery voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Battery current | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | State of charge Capacity | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Total BUS voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | On the BUS voltage | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BUCK-BOOST Current | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | LLC Current | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Temperture A | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Temperture B | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Discharge power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Charge power | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Discharge total energy of storg | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Charge total energy of storge d | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Reserved BDC mark (charge and dischar fault alarm code) Bit 0: Charge En; BDC allows char Bit 1: Discharge En; BDC allows discharge | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bit 2~7: Resvd; reserved Bit 8~11: Warn Sub Code; BDC sub-warning code Bit 12~15: Fault Sub Code; BDC sub-error code | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Lower BUS voltage Bms Max Volt Cell No | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bms Min Volt Cell No | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bms Battery Avg Temp | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bms Max Cell Temp | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bms Battery Avg Temp | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bms Max Cell Temp | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bms Battery Avg Temp | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bms Max SOC | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bms Min SOC Parallel Battery Num | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bms Derate Reason | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bms Gauge FCC(Ah) | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Bms Gauge RM(Ah) | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMS Protect 1 | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMSWarn 1 | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMS Fault 1 | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMS Fault 2 | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Battery ISO detection status | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | battery work request | — | — n | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | battery working status | — | — mancy ge harge | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — dby start t te | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMS Protect 2 | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMS Warn 2 | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMS SOC BMS Battery Volt | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMS Battery Curr | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | battery cell maximum temperatur | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Maximum charging current Maximum discharge current | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMSCycle Cnt | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMS SOH Battery charging voltage limit | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | Battery discharge voltage limit | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMS Warn 3 | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | BMS Protect 3 | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 3 | Input 1 Wattage | — | — | — | — | — | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
-| 32 | Input 8 Amperage | — | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | BMS Battery Single Volt Max | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | BMS Battery Single Volt Min | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Battery Load Volt | — | — 0,650.00] | — | — | — | — |
-| 32 | Input 8 Amperage | — | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 1 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 2 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 3 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 4 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 5 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 6 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 7 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 8 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 9 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 10 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 10 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 12 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 13 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 14 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 15 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Debug data 16 | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 1 output power H | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 1 output power L | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 2 output power H | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 2 output power L | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 1 energy Today H | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 1 energy Today L | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 2 energy Today H | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 2 energy Today L | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 1 energy Total H | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 1 energy Total L | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 2 energy Total H | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | PV inverter 2 energy Total L | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | battery pack number | — | — C reports e updated ery 15 nutes | — | — | — | — |
-| 32 | Input 8 Amperage | Battery pack serial number SN[0] | — | — C reports e updated | — | — | — | — |
-| 32 | Input 8 Amperage | Battery pack serial number SN[2] | — | — ery 15 | — | — | — | — |
-| 32 | Input 8 Amperage | Battery pack serial number SN[4] | — | — nutes | — | — | — | — |
-| 32 | Input 8 Amperage | Battery pack serial number SN[6] | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Battery pack serial number SN[8] | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Battery pack serial number SN[10]SN[11] | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Battery pack serial number SN[12]SN[13] | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Battery pack serial number SN[14]SN[15] | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Reserve | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | — | — | — | — | — | — | — |
-| 32 | Input 8 Amperage | Clear day data flag | — | — ta of the rrent day at the rver determines whether to clear. 0:not cleared. 1: Clear. | — | — | — | — |
-| 40 | Fault code | The first 8 registers are the 1 | — | — en 69 registers have the | — | — | — | — |
-| 41 | Intelligent Power Management temperature | same data area as 3165-3233, th 108 registers (including 8 regi | — | — eserved, a total of r). | — | — | — | — |
-| 41 | Intelligent Power Management temperature | The first 8 registers are the 1 | — | — en 69 registers have the | — | — | — | — |
-| 42 | Fault code | same data area as 3165-3233, th 108 registers (including 8 regi | — | — eserved, a total of r). | — | — | offgrid:fault_code | Fault code |
-| 48 | Input 1 energy today | The first 8 registers are the 1 | — | — en 69 registers have the | — | — | offgrid:input_1_energy_today | Input 1 energy today, PV1 energy produced today |
-| 49 | 71 | same data area as 3165-3233, th 108 registers (including 8 regi | — | — eserved, a total of r). | — | — | — | — |
-| 49 | 72- 10 | The first 8 registers are the 1 | — | — en 69 registers have the | — | — | — | — |
-| 50 | Input 1 total energy | same data area as 3165-3233, th 108 registers (including 8 regi | — | — eserved, a total of r). | — | — | offgrid:input_1_energy_total | Input 1 total energy, PV1 energy produced Lifetime |
+| 0 | Inverter status | Operating state reported by the inverter controller (0=waiting, 1=normal, 3=fault, 5=PV charge, 6=AC charge, 7=combined charge, 8=combined charge bypass, 9=PV charge bypass, 10=AC charge bypass, 11=bypass, 12=PV charge + discharge). | R | — | — | inverter_status_code | offgrid:status_code | Status code |
+| 1 | PV input power | Total PV input power summed across all strings (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | offgrid:input_1_voltage | Input 1 voltage, PV1 voltage |
+| 3 | PV 1 DC voltage | Instantaneous PV 1 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | offgrid:input_1_power | Input 1 Wattage, PV1 charge power |
+| 4 | PV 1 DC current | Instantaneous PV 1 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | — | — |
+| 5 | PV 1 DC power | Real-time DC power from PV 1 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | offgrid:input_2_power | Input 2 Wattage, PV2 charge power |
+| 7 | PV 2 DC voltage | Instantaneous PV 2 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | offgrid:input_1_amperage | Input 1 Amperage, PV1 buck current |
+| 8 | PV 2 DC current | Instantaneous PV 2 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | offgrid:input_2_amperage | Input 2 Amperage, PV2 buck current |
+| 9 | PV 2 DC power | Real-time DC power from PV 2 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | offgrid:output_active_power | Output active power |
+| 11 | PV 3 DC voltage | Instantaneous PV 3 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 12 | PV 3 DC current | Instantaneous PV 3 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | — | — |
+| 13 | PV 3 DC power | Real-time DC power from PV 3 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | offgrid:charge_power | Battery charge power, Charge Power |
+| 15 | PV 4 DC voltage | Instantaneous PV 4 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 16 | PV 4 DC current | Instantaneous PV 4 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | — | — |
+| 17 | PV 4 DC power | Real-time DC power from PV 4 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | offgrid:battery_voltage | Battery voltage |
+| 19 | PV 5 DC voltage | Instantaneous PV 5 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | offgrid:bus_voltage | Bus voltage |
+| 20 | PV 5 DC current | Instantaneous PV 5 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | offgrid:grid_voltage | Grid voltage |
+| 21 | PV 5 DC power | Real-time DC power from PV 5 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | offgrid:grid_frequency | AC frequency, Grid frequency |
+| 23 | PV 6 DC voltage | Instantaneous PV 6 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | offgrid:output_frequency | Output frequency |
+| 24 | PV 6 DC current | Instantaneous PV 6 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | offgrid:output_dc_voltage | Output DC voltage |
+| 25 | PV 6 DC power | Real-time DC power from PV 6 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | offgrid:inverter_temperature | Temperature |
+| 27 | PV 7 DC voltage | Instantaneous PV 7 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | offgrid:load_percent | Inverter load |
+| 28 | PV 7 DC current | Instantaneous PV 7 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | offgrid:battery_port_voltage | Battery port voltage |
+| 29 | PV 7 DC power | Real-time DC power from PV 7 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | offgrid:battery_bus_voltage | Battery bus voltage |
+| 31 | PV 8 DC voltage | Instantaneous PV 8 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 32 | PV 8 DC current | Instantaneous PV 8 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | — | — |
+| 33 | PV 8 DC power | Real-time DC power from PV 8 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 35 | AC output power | Active AC output power delivered by the inverter (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | — | — |
+| 37 | Grid frequency | Measured grid frequency with 0.01 Hz resolution. | R | — Hz | — | u 16_frequency_centihz | — | — |
+| 38 | AC phase L 1 voltage | AC output voltage for phase L 1. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 39 | AC phase L 1 current | AC output current for phase L 1. | R | — A | — | u 16_current_deciamp | — | — |
+| 40 | AC phase L 1 power | Active power exported on phase L 1. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 42 | AC phase L 2 voltage | AC output voltage for phase L 2. | R | — V | — | u 16_voltage_decivolt | offgrid:fault_code | Fault code |
+| 43 | AC phase L 2 current | AC output current for phase L 2. | R | — A | — | u 16_current_deciamp | offgrid:warning_code | Warning code |
+| 44 | AC phase L 2 power | Active power exported on phase L 2. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 46 | AC phase L 3 voltage | AC output voltage for phase L 3. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 47 | AC phase L 3 current | AC output current for phase L 3. | R | — A | — | u 16_current_deciamp | offgrid:constant_power | — |
+| 48 | AC phase L 3 power | Active power exported on phase L 3. | R | — W | — | u 32_power_w_decawatt | offgrid:input_1_energy_today | Input 1 energy today, PV1 energy produced today |
+| 53 | Output energy today | Energy exported to the AC output today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 55 | Output energy total | Lifetime AC output energy (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 57 | Run time | Total cumulative run time of the inverter. Raw values are seconds scaled by 1/7200 (0.0001389 hours). | R | — h | — | u 32_runtime_hours; Raw counter counts seconds; divide by 7200 to obtain hours. | — | — |
+| 59 | PV 1 energy today | Energy harvested by PV 1 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 61 | PV 1 energy total | Lifetime energy harvested by PV 1. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 63 | PV 2 energy today | Energy harvested by PV 2 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 65 | PV 2 energy total | Lifetime energy harvested by PV 2. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 67 | PV 3 energy today | Energy harvested by PV 3 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 69 | PV 3 energy total | Lifetime energy harvested by PV 3. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | offgrid:discharge_power | Battery discharge power, Discharge Power |
+| 71 | PV 4 energy today | Energy harvested by PV 4 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 73 | PV 4 energy total | Lifetime energy harvested by PV 4. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | offgrid:battery_discharge_amperage | Battery discharge current |
+| 75 | PV 5 energy today | Energy harvested by PV 5 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 77 | PV 5 energy total | Lifetime energy harvested by PV 5. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | offgrid:battery_power | Battery charging/ discharging(-ve) |
+| 79 | PV 6 energy today | Energy harvested by PV 6 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 81 | PV 6 energy total | Lifetime energy harvested by PV 6. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 83 | PV 7 energy today | Energy harvested by PV 7 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 85 | PV 7 energy total | Lifetime energy harvested by PV 7. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 87 | PV 8 energy today | Energy harvested by PV 8 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 89 | PV 8 energy total | Lifetime energy harvested by PV 8. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 91 | PV energy total | Total PV energy generated across all strings (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 93 | Inverter temperature | Main inverter heatsink temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 94 | IPM temperature | IPM (power module) temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 95 | Boost temperature | Boost inductor temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 98 | P-bus voltage | Positive DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 99 | N-bus voltage | Negative DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 101 | Output power percentage | Instantaneous AC output as a percentage of the inverter's rated power. | R | — % | — | u 16_percent | — | — |
+| 104 | Derating mode | Active derating reason reported by the inverter controller. | R | — | — | u 16_raw_code | — | — |
+| 105 | Fault code | Current inverter fault code (see protocol documentation). | R | — | — | u 16_status_word | — | — |
+| 110 | Warning code | Current inverter warning code (vendor-defined bitmask). | R | — | — | u 16_status_word | — | — |
+| 234 | Output reactive power | Instantaneous reactive power on the AC output (positive = inductive, negative = capacitive). | R | — var | — | s 32_reactive_power_decivar | — | — |
+| 236 | Reactive energy total | Lifetime accumulated reactive energy (0.1 kvarh resolution). | R | — kvarh | — | u 32_energy_kvarh_decitenth | — | — |
+| 3000 | Inverter status | Operating state reported by the inverter controller (0=waiting, 1=normal, 3=fault, 5=PV charge, 6=AC charge, 7=combined charge, 8=combined charge bypass, 9=PV charge bypass, 10=AC charge bypass, 11=bypass, 12=PV charge + discharge). | R | — | — | inverter_status_code | — | — |
+| 3001 | PV input power | Total PV input power summed across all strings (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3003 | PV 1 DC voltage | Instantaneous PV 1 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3004 | PV 1 DC current | Instantaneous PV 1 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | — | — |
+| 3005 | PV 1 DC power | Real-time DC power from PV 1 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3007 | PV 2 DC voltage | Instantaneous PV 2 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3008 | PV 2 DC current | Instantaneous PV 2 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | — | — |
+| 3009 | PV 2 DC power | Real-time DC power from PV 2 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3011 | PV 3 DC voltage | Instantaneous PV 3 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3012 | PV 3 DC current | Instantaneous PV 3 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | — | — |
+| 3013 | PV 3 DC power | Real-time DC power from PV 3 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3015 | PV 4 DC voltage | Instantaneous PV 4 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3016 | PV 4 DC current | Instantaneous PV 4 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | — | — |
+| 3017 | PV 4 DC power | Real-time DC power from PV 4 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3021 | Output reactive power | Instantaneous reactive power on the AC output (positive = inductive, negative = capacitive). | R | — var | — | s 32_reactive_power_decivar | — | — |
+| 3023 | AC output power | Active AC output power delivered by the inverter (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3025 | Grid frequency | Measured grid frequency with 0.01 Hz resolution. | R | — Hz | — | u 16_frequency_centihz | — | — |
+| 3026 | AC phase L 1 voltage | AC output voltage for phase L 1. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3027 | AC phase L 1 current | AC output current for phase L 1. | R | — A | — | u 16_current_deciamp | — | — |
+| 3028 | AC phase L 1 power | Active power exported on phase L 1. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3030 | AC phase L 2 voltage | AC output voltage for phase L 2. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3031 | AC phase L 2 current | AC output current for phase L 2. | R | — A | — | u 16_current_deciamp | — | — |
+| 3032 | AC phase L 2 power | Active power exported on phase L 2. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3034 | AC phase L 3 voltage | AC output voltage for phase L 3. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3035 | AC phase L 3 current | AC output current for phase L 3. | R | — A | — | u 16_current_deciamp | — | — |
+| 3036 | AC phase L 3 power | Active power exported on phase L 3. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3041 | Load supply power | Real-time active power delivered to on-site (self-consumption) loads. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3043 | Grid export power | Active power exported to the utility grid. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3045 | Home load power | Aggregate instantaneous demand from on-site loads. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3047 | Run time | Total cumulative run time of the inverter. Raw values are seconds scaled by 1/7200 (0.0001389 hours). | R | — h | — | u 32_runtime_hours; Raw counter counts seconds; divide by 7200 to obtain hours. | — | — |
+| 3049 | Output energy today | Energy exported to the AC output today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3051 | Output energy total | Lifetime AC output energy (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3053 | PV energy total | Total PV energy generated across all strings (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3055 | PV 1 energy today | Energy harvested by PV 1 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3057 | PV 1 energy total | Lifetime energy harvested by PV 1. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3059 | PV 2 energy today | Energy harvested by PV 2 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3061 | PV 2 energy total | Lifetime energy harvested by PV 2. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3063 | PV 3 energy today | Energy harvested by PV 3 today. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3065 | PV 3 energy total | Lifetime energy harvested by PV 3. Values use 0.1 k Wh resolution. | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3067 | Load energy today | Energy delivered to on-site loads today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3069 | Load energy total | Lifetime energy delivered to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3071 | Export energy today | Energy exported to the grid today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3073 | Export energy total | Lifetime energy exported to the grid (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3086 | Derating mode | Active derating reason reported by the inverter controller. | R | — | — | u 16_raw_code | — | — |
+| 3093 | Inverter temperature | Main inverter heatsink temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3094 | IPM temperature | IPM (power module) temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3095 | Boost temperature | Boost inductor temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3097 | Communication board temperature | Temperature reported by the communication/control board (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3098 | P-bus voltage | Positive DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3099 | N-bus voltage | Negative DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3101 | Output power percentage | Instantaneous AC output as a percentage of the inverter's rated power. | R | — % | — | u 16_percent | — | — |
+| 3105 | Fault code | Current inverter fault code (see protocol documentation). | R | — | — | u 16_status_word | — | — |
+| 3110 | Warning code | Current inverter warning code (vendor-defined bitmask). | R | — | — | u 16_status_word | — | — |
+| 3111 | Present FFT value (channel A) | Latest Fast Fourier Transform diagnostic value for channel A. | R | — | — | u 16_raw | — | — |
+| 3115 | Inverter start delay | Seconds remaining before restart once grid conditions recover. | R | — s | — | u 16_raw | — | — |
+| 3125 | Battery discharge today | Energy discharged from the battery into the AC system today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3127 | Battery discharge total | Total energy discharged from the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3129 | Battery charge today | Energy charged into the battery today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3131 | Battery charge total | Total energy charged into the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3164 | BDC presence flag | Indicates whether a battery DC converter (BDC) has been detected. | R | — | — | u 16_flag | — | — |
+| 3169 | Battery voltage | Pack voltage reported via the inverter-side measurements (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | — | — |
+| 3170 | Battery current | Current flowing between battery and inverter (positive = discharge) with 0.1 A resolution. | R | — A | — | s 16_current_deciamp | — | — |
+| 3171 | Battery SOC | Battery state of charge reported by the inverter. | R | — % | — | u 16_percent | — | — |
+| 3172 | VBUS 1 voltage | BDC high-side bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3173 | VBUS 2 voltage | BDC low-side bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3174 | Buck/boost current | Current through the BDC buck/boost stage (0.1 A resolution). | R | — A | — | u 16_current_deciamp | — | — |
+| 3175 | LLC stage current | Current through the LLC resonant stage (0.1 A resolution). | R | — A | — | u 16_current_deciamp | — | — |
+| 3176 | Battery temperature A | Battery temperature sensor A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3177 | Battery temperature B | Battery temperature sensor B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3178 | Battery discharge power | Real-time discharge power flowing from the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | — | — |
+| 3180 | Battery charge power | Real-time charge power flowing into the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | — | — |
+| 3189 | BMS max cell index | Cell index reporting the highest voltage in the battery stack (1-based). | R | — | — | u 16_raw | — | — |
+| 3190 | BMS min cell index | Cell index reporting the lowest voltage in the battery stack (1-based). | R | — | — | u 16_raw | — | — |
+| 3191 | BMS average temperature A | Average temperature reported by sensor group A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3192 | BMS max cell temperature A | Maximum cell temperature within sensor group A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3193 | BMS average temperature B | Average temperature reported by sensor group B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3194 | BMS max cell temperature B | Maximum cell temperature within sensor group B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3195 | BMS average temperature C | Average temperature reported by sensor group C (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3196 | BMS max SOC | Highest state of charge observed across battery modules. | R | — % | — | u 16_percent | — | — |
+| 3197 | BMS min SOC | Lowest state of charge observed across battery modules. | R | — % | — | u 16_percent | — | — |
+| 3198 | Parallel battery count | Number of battery modules detected in parallel. | R | — | — | u 16_raw | — | — |
+| 3199 | BMS derate reason | Reason code reported by the BMS for power derating. | R | — | — | u 16_raw | — | — |
+| 3200 | BMS full charge capacity | Full charge capacity (FCC) reported by the battery fuel gauge (Ah). | R | — Ah | — | u 16_ampere_hour | — | — |
+| 3201 | BMS remaining capacity | Remaining capacity (RM) reported by the battery fuel gauge (Ah). | R | — Ah | — | u 16_ampere_hour | — | — |
+| 3202 | BMS protect flags 1 | Protection bitmask word 1 from the battery management system. | R | — | — | u 16_raw | — | — |
+| 3203 | BMS warning flags 1 | Warning bitmask word 1 from the battery management system. | R | — | — | u 16_raw | — | — |
+| 3204 | BMS fault flags 1 | Fault bitmask word 1 from the battery management system. | R | — | — | u 16_raw | — | — |
+| 3205 | BMS fault flags 2 | Fault bitmask word 2 from the battery management system. | R | — | — | u 16_raw | — | — |
+| 3210 | Battery insulation status | Isolation detection status reported by the BMS (0 = not detected, 1 = detected). | R | — | — | u 16_raw | — | — |
+| 3211 | Battery request flags | Bitmask of requests from the BMS to the inverter (charge/discharge permissions). | R | — | — | u 16_raw | — | — |
+| 3212 | BMS status | Overall battery management system status code. | R | — | — | u 16_raw | — | — |
+| 3213 | BMS protect flags 2 | Protection bitmask word 2 from the battery management system. | R | — | — | u 16_raw | — | — |
+| 3214 | BMS warning flags 2 | Warning bitmask word 2 from the battery management system. | R | — | — | u 16_raw | — | — |
+| 3215 | BMS SOC | State of charge reported directly by the BMS. | R | — % | — | u 16_percent | — | — |
+| 3216 | BMS battery voltage | Pack voltage reported by the BMS (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | — | — |
+| 3217 | BMS battery current | Current reported by the BMS with 0.01 A resolution (positive = discharge). | R | — A | — | s 16_current_centiamp; Positive values indicate discharge from the battery; negative values indicate charging. | — | — |
+| 3218 | BMS max cell temperature | Maximum cell temperature observed across the battery pack (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
+| 3219 | BMS max charge current | Maximum charge current allowed by the BMS (0.01 A resolution). | R | — A | — | u 16_current_centiamp | — | — |
+| 3220 | BMS max discharge current | Maximum discharge current allowed by the BMS (0.01 A resolution). | R | — A | — | u 16_current_centiamp | — | — |
+| 3221 | BMS cycle count | Total charge/discharge cycles counted by the BMS. | R | — | — | u 16_raw | — | — |
+| 3222 | BMS state of health | Battery state of health reported by the BMS. | R | — % | — | u 16_percent | — | — |
+| 3223 | BMS charge voltage limit | Maximum pack voltage permitted during charge (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | — | — |
+| 3224 | BMS discharge voltage limit | Minimum pack voltage permitted during discharge (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | — | — |
+| 3225 | BMS warning flags 3 | Warning bitmask word 3 from the battery management system. | R | — | — | u 16_raw | — | — |
+| 3226 | BMS protect flags 3 | Protection bitmask word 3 from the battery management system. | R | — | — | u 16_raw | — | — |
+| 3230 | BMS max cell voltage | Highest individual cell voltage (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | — | — |
+| 3231 | BMS min cell voltage | Lowest individual cell voltage (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | — | — |
 


### PR DESCRIPTION
## Summary
- tighten the data type inference in `build_input_spec.py` so percent, amp-hour and voltage fields map to the correct reusable types and add a signed centiamp definition for BMS currents
- regenerate the input register spec JSON to use the new types for TL-X/TL-XH telemetry, including SOC, battery current, and BMS charge limits
- refresh the rendered markdown tables to reflect the corrected units and data types

## Testing
- python doc/build_input_spec.py
- python doc/render_register_spec.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc6d223308330b219985213e1cf73