### PR TITLE
Update TL-XH input register metadata

### DIFF
--- a/doc/growatt_register_data_types.json
+++ b/doc/growatt_register_data_types.json
@@ -1189,6 +1189,70 @@
       "bits": 16,
       "scale": 100,
       "unit": "A"
+    },
+    "u16_resistance_kiloohm": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 1,
+      "unit": "kΩ",
+      "notes": "PV insulation resistance reported in kilo-ohms."
+    },
+    "u16_current_decimilliamp": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 10,
+      "unit": "mA",
+      "notes": "Divide by 10 to obtain milliamps."
+    },
+    "u16_current_milliamp": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 1,
+      "unit": "mA"
+    },
+    "u32_apparent_power_decava": {
+      "kind": "scaled",
+      "registers": 2,
+      "bits": 32,
+      "scale": 10,
+      "unit": "VA",
+      "notes": "Unsigned 32-bit apparent power value with 0.1 VA resolution (high word first)."
+    },
+    "u16_percent_decitenth": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 10,
+      "unit": "%",
+      "notes": "Divide by 10 for percent values."
+    },
+    "u16_power_factor_decitenth": {
+      "kind": "scaled",
+      "registers": 1,
+      "bits": 16,
+      "scale": 10,
+      "unit": "pf",
+      "notes": "Divide by 10 to obtain the power factor."
+    },
+    "priority_mode": {
+      "kind": "enum",
+      "registers": 1,
+      "bits": 16,
+      "values": {
+        "0": {
+          "label": "load_first"
+        },
+        "1": {
+          "label": "battery_first"
+        },
+        "2": {
+          "label": "grid_first"
+        }
+      },
+      "notes": "Hybrid priority mode selector."
     }
   },
   "register_types": [
@@ -3436,6 +3500,17 @@
     },
     {
       "table": "input",
+      "register": 3019,
+      "register_end": 3020,
+      "type": "u32_power_w_decawatt",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
       "register": 3021,
       "register_end": 3022,
       "type": "s32_reactive_power_decivar",
@@ -3575,6 +3650,39 @@
         "output_3_power"
       ],
       "families": [
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3038,
+      "register_end": 3038,
+      "type": "u16_voltage_decivolt",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3039,
+      "register_end": 3039,
+      "type": "u16_voltage_decivolt",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3040,
+      "register_end": 3040,
+      "type": "u16_voltage_decivolt",
+      "attributes": [],
+      "families": [
+        "storage",
         "tlx"
       ]
     },
@@ -3791,6 +3899,61 @@
     },
     {
       "table": "input",
+      "register": 3075,
+      "register_end": 3076,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3077,
+      "register_end": 3078,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3079,
+      "register_end": 3080,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3081,
+      "register_end": 3082,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3083,
+      "register_end": 3084,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
       "register": 3086,
       "register_end": 3086,
       "type": "u16_raw_code",
@@ -3798,6 +3961,72 @@
         "derating_mode"
       ],
       "families": [
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3087,
+      "register_end": 3087,
+      "type": "u16_resistance_kiloohm",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3088,
+      "register_end": 3088,
+      "type": "u16_current_decimilliamp",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3089,
+      "register_end": 3089,
+      "type": "u16_current_decimilliamp",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3090,
+      "register_end": 3090,
+      "type": "u16_current_decimilliamp",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3091,
+      "register_end": 3091,
+      "type": "u16_current_milliamp",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3092,
+      "register_end": 3092,
+      "type": "u16_voltage_decivolt",
+      "attributes": [],
+      "families": [
+        "storage",
         "tlx"
       ]
     },
@@ -3876,6 +4105,17 @@
     },
     {
       "table": "input",
+      "register": 3100,
+      "register_end": 3100,
+      "type": "power_factor_x10000",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
       "register": 3101,
       "register_end": 3101,
       "type": "u16_percent",
@@ -3888,6 +4128,28 @@
     },
     {
       "table": "input",
+      "register": 3102,
+      "register_end": 3103,
+      "type": "u32_power_w_decawatt",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3104,
+      "register_end": 3104,
+      "type": "u16_status_word",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
       "register": 3105,
       "register_end": 3105,
       "type": "u16_status_word",
@@ -3895,6 +4157,39 @@
         "fault_code"
       ],
       "families": [
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3106,
+      "register_end": 3106,
+      "type": "u16_raw_code",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3107,
+      "register_end": 3107,
+      "type": "u16_status_word",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3108,
+      "register_end": 3108,
+      "type": "u16_status_word",
+      "attributes": [],
+      "families": [
+        "storage",
         "tlx"
       ]
     },
@@ -3925,12 +4220,89 @@
     },
     {
       "table": "input",
+      "register": 3112,
+      "register_end": 3112,
+      "type": "u16_raw_code",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3113,
+      "register_end": 3113,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3114,
+      "register_end": 3114,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
       "register": 3115,
       "register_end": 3115,
       "type": "u16_raw",
       "attributes": [
         "inv_start_delay"
       ],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3118,
+      "register_end": 3118,
+      "type": "bdc_onoff_state_flag",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3119,
+      "register_end": 3119,
+      "type": "boolean_flag",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3121,
+      "register_end": 3122,
+      "type": "u32_power_w_decawatt",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3123,
+      "register_end": 3124,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
       "families": [
         "storage",
         "tlx"
@@ -3990,12 +4362,276 @@
     },
     {
       "table": "input",
+      "register": 3133,
+      "register_end": 3134,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3135,
+      "register_end": 3136,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3137,
+      "register_end": 3138,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3139,
+      "register_end": 3140,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3141,
+      "register_end": 3142,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3144,
+      "register_end": 3144,
+      "type": "priority_mode",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3145,
+      "register_end": 3145,
+      "type": "u16_frequency_centihz",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3146,
+      "register_end": 3146,
+      "type": "u16_voltage_decivolt",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3147,
+      "register_end": 3147,
+      "type": "u16_current_deciamp",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3148,
+      "register_end": 3149,
+      "type": "u32_apparent_power_decava",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3150,
+      "register_end": 3150,
+      "type": "u16_voltage_decivolt",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3151,
+      "register_end": 3151,
+      "type": "u16_current_deciamp",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3152,
+      "register_end": 3153,
+      "type": "u32_apparent_power_decava",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3154,
+      "register_end": 3154,
+      "type": "u16_voltage_decivolt",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3155,
+      "register_end": 3155,
+      "type": "u16_current_deciamp",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3156,
+      "register_end": 3157,
+      "type": "u32_apparent_power_decava",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3158,
+      "register_end": 3159,
+      "type": "u32_apparent_power_decava",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3160,
+      "register_end": 3160,
+      "type": "u16_percent_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3161,
+      "register_end": 3161,
+      "type": "u16_power_factor_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3162,
+      "register_end": 3162,
+      "type": "u16_voltage_millivolt",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
       "register": 3164,
       "register_end": 3164,
       "type": "u16_flag",
       "attributes": [
         "bdc_new_flag"
       ],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3165,
+      "register_end": 3165,
+      "type": "u16_raw_code",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3166,
+      "register_end": 3166,
+      "type": "u16_raw_code",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3167,
+      "register_end": 3167,
+      "type": "u16_raw_code",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3168,
+      "register_end": 3168,
+      "type": "u16_raw_code",
+      "attributes": [],
       "families": [
         "storage",
         "tlx"
@@ -4139,6 +4775,50 @@
       "attributes": [
         "charge_power"
       ],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3182,
+      "register_end": 3183,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3184,
+      "register_end": 3185,
+      "type": "u32_energy_kwh_decitenth",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3187,
+      "register_end": 3187,
+      "type": "u16_status_word",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3188,
+      "register_end": 3188,
+      "type": "u16_voltage_decivolt",
+      "attributes": [],
       "families": [
         "storage",
         "tlx"
@@ -4607,6 +5287,193 @@
       "attributes": [
         "bms_cell_volt_min"
       ],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3232,
+      "register_end": 3232,
+      "type": "u16_voltage_centivolt",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3234,
+      "register_end": 3234,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3235,
+      "register_end": 3235,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3236,
+      "register_end": 3236,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3237,
+      "register_end": 3237,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3238,
+      "register_end": 3238,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3239,
+      "register_end": 3239,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3240,
+      "register_end": 3240,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3241,
+      "register_end": 3241,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3242,
+      "register_end": 3242,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3243,
+      "register_end": 3243,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3244,
+      "register_end": 3244,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3245,
+      "register_end": 3245,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3246,
+      "register_end": 3246,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3247,
+      "register_end": 3247,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3248,
+      "register_end": 3248,
+      "type": "u16_raw",
+      "attributes": [],
+      "families": [
+        "storage",
+        "tlx"
+      ]
+    },
+    {
+      "table": "input",
+      "register": 3249,
+      "register_end": 3249,
+      "type": "u16_raw",
+      "attributes": [],
       "families": [
         "storage",
         "tlx"

--- a/doc/growatt_registers_spec.json
+++ b/doc/growatt_registers_spec.json
@@ -6384,6 +6384,18 @@
     {
       "type": "entry",
       "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3019,
+      "register_start": 3019,
+      "register_end": 3020,
+      "name": "System output power",
+      "description": "AC output power reported by the TL-XH mirror block (0.1 W resolution). Mirrors the value at register 35.",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
       "register": 3021,
       "register_start": 3021,
       "register_end": 3022,
@@ -6560,6 +6572,42 @@
       "attributes": [
         "output_3_power"
       ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3038,
+      "register_start": 3038,
+      "register_end": 3038,
+      "name": "RS line voltage",
+      "description": "Line-to-line voltage between phases R and S measured on the AC output.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3039,
+      "register_start": 3039,
+      "register_end": 3039,
+      "name": "ST line voltage",
+      "description": "Line-to-line voltage between phases S and T measured on the AC output.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3040,
+      "register_start": 3040,
+      "register_end": 3040,
+      "name": "TR line voltage",
+      "description": "Line-to-line voltage between phases T and R measured on the AC output.",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt"
     },
     {
       "type": "entry",
@@ -6820,6 +6868,66 @@
     {
       "type": "entry",
       "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3075,
+      "register_start": 3075,
+      "register_end": 3076,
+      "name": "User load energy today",
+      "description": "Energy delivered to on-site loads today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3077,
+      "register_start": 3077,
+      "register_end": 3078,
+      "name": "User load energy total",
+      "description": "Lifetime energy delivered to on-site loads (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3079,
+      "register_start": 3079,
+      "register_end": 3080,
+      "name": "PV4 energy today",
+      "description": "Energy harvested by PV string 4 today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3081,
+      "register_start": 3081,
+      "register_end": 3082,
+      "name": "PV4 energy total",
+      "description": "Lifetime energy harvested by PV string 4 (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3083,
+      "register_start": 3083,
+      "register_end": 3084,
+      "name": "PV energy today",
+      "description": "Total PV energy harvested across all strings today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
       "register": 3086,
       "register_start": 3086,
       "register_end": 3086,
@@ -6831,6 +6939,78 @@
       "attributes": [
         "derating_mode"
       ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3087,
+      "register_start": 3087,
+      "register_end": 3087,
+      "name": "PV insulation resistance",
+      "description": "DC insulation resistance measured on the PV inputs.",
+      "access": "R",
+      "unit": "kΩ",
+      "data_type": "u16_resistance_kiloohm"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3088,
+      "register_start": 3088,
+      "register_end": 3088,
+      "name": "Residual current R",
+      "description": "Ground fault residual current on phase R (0.1 mA resolution).",
+      "access": "R",
+      "unit": "mA",
+      "data_type": "u16_current_decimilliamp"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3089,
+      "register_start": 3089,
+      "register_end": 3089,
+      "name": "Residual current S",
+      "description": "Ground fault residual current on phase S (0.1 mA resolution).",
+      "access": "R",
+      "unit": "mA",
+      "data_type": "u16_current_decimilliamp"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3090,
+      "register_start": 3090,
+      "register_end": 3090,
+      "name": "Residual current T",
+      "description": "Ground fault residual current on phase T (0.1 mA resolution).",
+      "access": "R",
+      "unit": "mA",
+      "data_type": "u16_current_decimilliamp"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3091,
+      "register_start": 3091,
+      "register_end": 3091,
+      "name": "GFCI current",
+      "description": "Ground fault current measured by the GFCI sensor (1 mA resolution).",
+      "access": "R",
+      "unit": "mA",
+      "data_type": "u16_current_milliamp"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3092,
+      "register_start": 3092,
+      "register_end": 3092,
+      "name": "Total bus voltage",
+      "description": "Combined DC bus voltage measured at the inverter bridge (0.1 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt"
     },
     {
       "type": "entry",
@@ -6925,6 +7105,18 @@
     {
       "type": "entry",
       "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3100,
+      "register_start": 3100,
+      "register_end": 3100,
+      "name": "Inverter output power factor",
+      "description": "Instantaneous output power factor encoded as value ×10 000 (10 000 = unity).",
+      "access": "R",
+      "unit": "pf",
+      "data_type": "power_factor_x10000"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
       "register": 3101,
       "register_start": 3101,
       "register_end": 3101,
@@ -6940,6 +7132,30 @@
     {
       "type": "entry",
       "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3102,
+      "register_start": 3102,
+      "register_end": 3103,
+      "name": "Output max power limit",
+      "description": "Current active output power limit enforced by the inverter (0.1 W resolution).",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3104,
+      "register_start": 3104,
+      "register_end": 3104,
+      "name": "Standby flags",
+      "description": "Bitmask reporting standby reasons for the inverter (vendor-defined).",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_status_word"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
       "register": 3105,
       "register_start": 3105,
       "register_end": 3105,
@@ -6951,6 +7167,42 @@
       "attributes": [
         "fault_code"
       ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3106,
+      "register_start": 3106,
+      "register_end": 3106,
+      "name": "Warning main code",
+      "description": "Current warning main code reported by the inverter controller.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw_code"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3107,
+      "register_start": 3107,
+      "register_end": 3107,
+      "name": "Fault subcode",
+      "description": "Fault detail bitmask identifying the root cause of the active fault.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_status_word"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3108,
+      "register_start": 3108,
+      "register_end": 3108,
+      "name": "Warning subcode",
+      "description": "Warning detail bitmask reported alongside the main warning code.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_status_word"
     },
     {
       "type": "entry",
@@ -6985,6 +7237,42 @@
     {
       "type": "entry",
       "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3112,
+      "register_start": 3112,
+      "register_end": 3112,
+      "name": "AFCI status",
+      "description": "Arc-fault detection controller status word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw_code"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3113,
+      "register_start": 3113,
+      "register_end": 3113,
+      "name": "AFCI strength (channel A)",
+      "description": "Arc-fault detection strength metric for channel A.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3114,
+      "register_start": 3114,
+      "register_end": 3114,
+      "name": "AFCI self-check (channel A)",
+      "description": "Result of the AFCI self-test for channel A.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
       "register": 3115,
       "register_start": 3115,
       "register_end": 3115,
@@ -6996,6 +7284,54 @@
       "attributes": [
         "inv_start_delay"
       ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3118,
+      "register_start": 3118,
+      "register_end": 3118,
+      "name": "BDC connect state",
+      "description": "Indicates whether the battery DC converter is connected (0 = off, 1 = on).",
+      "access": "R",
+      "unit": null,
+      "data_type": "bdc_onoff_state_flag"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3119,
+      "register_start": 3119,
+      "register_end": 3119,
+      "name": "Dry contact state",
+      "description": "Status of the dry contact output (0 = open, 1 = closed).",
+      "access": "R",
+      "unit": null,
+      "data_type": "boolean_flag"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3121,
+      "register_start": 3121,
+      "register_end": 3122,
+      "name": "Self-use power",
+      "description": "Real-time power consumed by on-site loads (0.1 W resolution).",
+      "access": "R",
+      "unit": "W",
+      "data_type": "u32_power_w_decawatt"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH PV/AC telemetry (3000–3124)",
+      "register": 3123,
+      "register_start": 3123,
+      "register_end": 3124,
+      "name": "System energy today",
+      "description": "Total energy processed by the hybrid system today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
     },
     {
       "type": "section",
@@ -7064,6 +7400,246 @@
     {
       "type": "entry",
       "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3133,
+      "register_start": 3133,
+      "register_end": 3134,
+      "name": "AC charge energy today",
+      "description": "Energy charged into the battery from AC today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3135,
+      "register_start": 3135,
+      "register_end": 3136,
+      "name": "AC charge energy total",
+      "description": "Lifetime energy charged into the battery from AC (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3137,
+      "register_start": 3137,
+      "register_end": 3138,
+      "name": "System energy total",
+      "description": "Lifetime hybrid system energy throughput (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3139,
+      "register_start": 3139,
+      "register_end": 3140,
+      "name": "Self-use energy today",
+      "description": "Energy supplied to on-site loads today (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3141,
+      "register_start": 3141,
+      "register_end": 3142,
+      "name": "Self-use energy total",
+      "description": "Lifetime energy supplied to on-site loads (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3144,
+      "register_start": 3144,
+      "register_end": 3144,
+      "name": "Priority mode",
+      "description": "Operating priority mode: 0 = load-first, 1 = battery-first, 2 = grid-first.",
+      "access": "R",
+      "unit": null,
+      "data_type": "priority_mode"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3145,
+      "register_start": 3145,
+      "register_end": 3145,
+      "name": "EPS frequency",
+      "description": "Output frequency of the EPS (backup) inverter (0.01 Hz resolution).",
+      "access": "R",
+      "unit": "Hz",
+      "data_type": "u16_frequency_centihz"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3146,
+      "register_start": 3146,
+      "register_end": 3146,
+      "name": "EPS phase R voltage",
+      "description": "Phase R voltage on the EPS output (0.1 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3147,
+      "register_start": 3147,
+      "register_end": 3147,
+      "name": "EPS phase R current",
+      "description": "Phase R current on the EPS output (0.1 A resolution).",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3148,
+      "register_start": 3148,
+      "register_end": 3149,
+      "name": "EPS phase R apparent power",
+      "description": "Phase R apparent power on the EPS output (0.1 VA resolution).",
+      "access": "R",
+      "unit": "VA",
+      "data_type": "u32_apparent_power_decava"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3150,
+      "register_start": 3150,
+      "register_end": 3150,
+      "name": "EPS phase S voltage",
+      "description": "Phase S voltage on the EPS output (0.1 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3151,
+      "register_start": 3151,
+      "register_end": 3151,
+      "name": "EPS phase S current",
+      "description": "Phase S current on the EPS output (0.1 A resolution).",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3152,
+      "register_start": 3152,
+      "register_end": 3153,
+      "name": "EPS phase S apparent power",
+      "description": "Phase S apparent power on the EPS output (0.1 VA resolution).",
+      "access": "R",
+      "unit": "VA",
+      "data_type": "u32_apparent_power_decava"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3154,
+      "register_start": 3154,
+      "register_end": 3154,
+      "name": "EPS phase T voltage",
+      "description": "Phase T voltage on the EPS output (0.1 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3155,
+      "register_start": 3155,
+      "register_end": 3155,
+      "name": "EPS phase T current",
+      "description": "Phase T current on the EPS output (0.1 A resolution).",
+      "access": "R",
+      "unit": "A",
+      "data_type": "u16_current_deciamp"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3156,
+      "register_start": 3156,
+      "register_end": 3157,
+      "name": "EPS phase T apparent power",
+      "description": "Phase T apparent power on the EPS output (0.1 VA resolution).",
+      "access": "R",
+      "unit": "VA",
+      "data_type": "u32_apparent_power_decava"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3158,
+      "register_start": 3158,
+      "register_end": 3159,
+      "name": "EPS total apparent power",
+      "description": "Total apparent power delivered by the EPS output (0.1 VA resolution).",
+      "access": "R",
+      "unit": "VA",
+      "data_type": "u32_apparent_power_decava"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3160,
+      "register_start": 3160,
+      "register_end": 3160,
+      "name": "EPS load percentage",
+      "description": "Utilisation of the EPS output expressed as a percentage of rating (0.1 % resolution).",
+      "access": "R",
+      "unit": "%",
+      "data_type": "u16_percent_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3161,
+      "register_start": 3161,
+      "register_end": 3161,
+      "name": "BDC power factor",
+      "description": "Battery DC converter power factor estimate (0.1 resolution).",
+      "access": "R",
+      "unit": "pf",
+      "data_type": "u16_power_factor_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3162,
+      "register_start": 3162,
+      "register_end": 3162,
+      "name": "BDC DC voltage",
+      "description": "High-voltage DC bus measurement from the BDC (0.001 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_millivolt"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
       "register": 3164,
       "register_start": 3164,
       "register_end": 3164,
@@ -7075,6 +7651,54 @@
       "attributes": [
         "bdc_new_flag"
       ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3165,
+      "register_start": 3165,
+      "register_end": 3165,
+      "name": "BDC derating mode",
+      "description": "Derating reason code reported by the battery DC converter.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw_code"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3166,
+      "register_start": 3166,
+      "register_end": 3166,
+      "name": "BDC system mode",
+      "description": "Operating state reported by the battery DC converter controller.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw_code"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3167,
+      "register_start": 3167,
+      "register_end": 3167,
+      "name": "BDC fault code",
+      "description": "Current fault code reported by the battery DC converter.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw_code"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3168,
+      "register_start": 3168,
+      "register_end": 3168,
+      "name": "BDC warning code",
+      "description": "Current warning code reported by the battery DC converter.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw_code"
     },
     {
       "type": "entry",
@@ -7244,6 +7868,54 @@
     {
       "type": "entry",
       "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3182,
+      "register_start": 3182,
+      "register_end": 3183,
+      "name": "BDC discharge energy total",
+      "description": "Lifetime energy discharged by the battery DC converter (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3184,
+      "register_start": 3184,
+      "register_end": 3185,
+      "name": "BDC charge energy total",
+      "description": "Lifetime energy charged into the battery via the BDC (0.1 kWh resolution).",
+      "access": "R",
+      "unit": "kWh",
+      "data_type": "u32_energy_kwh_decitenth"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3187,
+      "register_start": 3187,
+      "register_end": 3187,
+      "name": "BDC flag word",
+      "description": "Diagnostic flag bitmask reported by the battery DC converter.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_status_word"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
+      "register": 3188,
+      "register_start": 3188,
+      "register_end": 3188,
+      "name": "VBUS2 low voltage",
+      "description": "Low-side DC bus voltage reported by the BDC (0.1 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_decivolt"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH battery telemetry (3125–3199)",
       "register": 3189,
       "register_start": 3189,
       "register_end": 3189,
@@ -7408,11 +8080,11 @@
     },
     {
       "type": "section",
-      "title": "TL-X/TL-XH BMS diagnostics (3200–3231)"
+      "title": "TL-X/TL-XH BMS and debug telemetry (3200–3249)"
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3200,
       "register_start": 3200,
       "register_end": 3200,
@@ -7427,7 +8099,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3201,
       "register_start": 3201,
       "register_end": 3201,
@@ -7442,7 +8114,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3202,
       "register_start": 3202,
       "register_end": 3202,
@@ -7457,7 +8129,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3203,
       "register_start": 3203,
       "register_end": 3203,
@@ -7472,7 +8144,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3204,
       "register_start": 3204,
       "register_end": 3204,
@@ -7487,7 +8159,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3205,
       "register_start": 3205,
       "register_end": 3205,
@@ -7502,7 +8174,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3210,
       "register_start": 3210,
       "register_end": 3210,
@@ -7517,7 +8189,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3211,
       "register_start": 3211,
       "register_end": 3211,
@@ -7532,7 +8204,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3212,
       "register_start": 3212,
       "register_end": 3212,
@@ -7547,7 +8219,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3213,
       "register_start": 3213,
       "register_end": 3213,
@@ -7562,7 +8234,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3214,
       "register_start": 3214,
       "register_end": 3214,
@@ -7577,7 +8249,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3215,
       "register_start": 3215,
       "register_end": 3215,
@@ -7592,7 +8264,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3216,
       "register_start": 3216,
       "register_end": 3216,
@@ -7607,7 +8279,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3217,
       "register_start": 3217,
       "register_end": 3217,
@@ -7623,7 +8295,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3218,
       "register_start": 3218,
       "register_end": 3218,
@@ -7638,7 +8310,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3219,
       "register_start": 3219,
       "register_end": 3219,
@@ -7653,7 +8325,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3220,
       "register_start": 3220,
       "register_end": 3220,
@@ -7668,7 +8340,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3221,
       "register_start": 3221,
       "register_end": 3221,
@@ -7683,7 +8355,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3222,
       "register_start": 3222,
       "register_end": 3222,
@@ -7698,7 +8370,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3223,
       "register_start": 3223,
       "register_end": 3223,
@@ -7713,7 +8385,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3224,
       "register_start": 3224,
       "register_end": 3224,
@@ -7728,7 +8400,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3225,
       "register_start": 3225,
       "register_end": 3225,
@@ -7743,7 +8415,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3226,
       "register_start": 3226,
       "register_end": 3226,
@@ -7758,7 +8430,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3230,
       "register_start": 3230,
       "register_end": 3230,
@@ -7773,7 +8445,7 @@
     },
     {
       "type": "entry",
-      "section": "TL-X/TL-XH BMS diagnostics (3200–3231)",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
       "register": 3231,
       "register_start": 3231,
       "register_end": 3231,
@@ -7785,6 +8457,210 @@
       "attributes": [
         "bms_cell_volt_min"
       ]
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3232,
+      "register_start": 3232,
+      "register_end": 3232,
+      "name": "Battery load voltage",
+      "description": "Battery-side load voltage measurement (0.01 V resolution).",
+      "access": "R",
+      "unit": "V",
+      "data_type": "u16_voltage_centivolt"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3234,
+      "register_start": 3234,
+      "register_end": 3234,
+      "name": "Debug data 1",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3235,
+      "register_start": 3235,
+      "register_end": 3235,
+      "name": "Debug data 2",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3236,
+      "register_start": 3236,
+      "register_end": 3236,
+      "name": "Debug data 3",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3237,
+      "register_start": 3237,
+      "register_end": 3237,
+      "name": "Debug data 4",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3238,
+      "register_start": 3238,
+      "register_end": 3238,
+      "name": "Debug data 5",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3239,
+      "register_start": 3239,
+      "register_end": 3239,
+      "name": "Debug data 6",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3240,
+      "register_start": 3240,
+      "register_end": 3240,
+      "name": "Debug data 7",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3241,
+      "register_start": 3241,
+      "register_end": 3241,
+      "name": "Debug data 8",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3242,
+      "register_start": 3242,
+      "register_end": 3242,
+      "name": "Debug data 9",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3243,
+      "register_start": 3243,
+      "register_end": 3243,
+      "name": "Debug data 10",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3244,
+      "register_start": 3244,
+      "register_end": 3244,
+      "name": "Debug data 11",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3245,
+      "register_start": 3245,
+      "register_end": 3245,
+      "name": "Debug data 12",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3246,
+      "register_start": 3246,
+      "register_end": 3246,
+      "name": "Debug data 13",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3247,
+      "register_start": 3247,
+      "register_end": 3247,
+      "name": "Debug data 14",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3248,
+      "register_start": 3248,
+      "register_end": 3248,
+      "name": "Debug data 15",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
+    },
+    {
+      "type": "entry",
+      "section": "TL-X/TL-XH BMS and debug telemetry (3200–3249)",
+      "register": 3249,
+      "register_start": 3249,
+      "register_end": 3249,
+      "name": "Debug data 16",
+      "description": "Vendor-specific diagnostic word.",
+      "access": "R",
+      "unit": null,
+      "data_type": "u16_raw"
     }
   ]
 }

--- a/doc/growatt_registers_spec.md
+++ b/doc/growatt_registers_spec.md
@@ -17,14 +17,14 @@ This file is generated from `growatt_registers_spec.json` (parsed from the offic
 | Storage Holding Registers (1000–1124) | 35 | 0 | 35 |
 | Storage Holding Registers (1125–1249) | 15 | 0 | 15 |
 | Common Input Registers (0–124) | 66 | 66 | 0 |
-| TL-X/TL-XH Input Registers (3000–3124) | 55 | 55 | 0 |
-| TL-X/TL-XH Battery & Hybrid Input Registers (3125–3249) | 52 | 52 | 0 |
+| TL-X/TL-XH Input Registers (3000–3124) | 83 | 55 | 28 |
+| TL-X/TL-XH Battery & Hybrid Input Registers (3125–3249) | 97 | 52 | 45 |
 | TL-X/TL-XH Extended Input Registers (3250–3374) | 0 | 0 | 0 |
 | Storage Input Registers (1000–1124) | 0 | 0 | 0 |
 | Storage Input Registers (1125–1249) | 0 | 0 | 0 |
 | Storage Input Registers (2000–2124) | 0 | 0 | 0 |
-| Storage TL-XH Input Registers (3041–3231) | 81 | 62 | 19 |
-| Offgrid SPF Input Registers | 175 | 25 | 150 |
+| Storage TL-XH Input Registers (3041–3231) | 133 | 62 | 71 |
+| Offgrid SPF Input Registers | 248 | 25 | 223 |
 
 ## Common Holding Registers (0–124)
 Applies to TL-X/TL-XH, TL3/MAX/MID/MAC, and MIX/SPA/SPH storage families.
@@ -492,6 +492,7 @@ Primary TL-X/TL-XH telemetry mirror (PV/AC metrics).
 | 3015 | PV 4 DC voltage | Instantaneous PV 4 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | tlx:input_4_voltage | Input 4 voltage |
 | 3016 | PV 4 DC current | Instantaneous PV 4 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | tlx:input_4_amperage | Input 4 Amperage |
 | 3017 | PV 4 DC power | Real-time DC power from PV 4 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | tlx:input_4_power | Input 4 Wattage |
+| 3019 | System output power | AC output power reported by the TL-XH mirror block (0.1 W resolution). Mirrors the value at register 35. | R | — W | — | u 32_power_w_decawatt | — | — |
 | 3021 | Output reactive power | Instantaneous reactive power on the AC output (positive = inductive, negative = capacitive). | R | — var | — | s 32_reactive_power_decivar | tlx:output_reactive_power | Reactive wattage |
 | 3023 | AC output power | Active AC output power delivered by the inverter (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | tlx:output_power | Output power |
 | 3025 | Grid frequency | Measured grid frequency with 0.01 Hz resolution. | R | — Hz | — | u 16_frequency_centihz | tlx:grid_frequency | AC frequency, Grid frequency |
@@ -504,6 +505,9 @@ Primary TL-X/TL-XH telemetry mirror (PV/AC metrics).
 | 3034 | AC phase L 3 voltage | AC output voltage for phase L 3. | R | — V | — | u 16_voltage_decivolt | tlx:output_3_voltage | Output 3 voltage |
 | 3035 | AC phase L 3 current | AC output current for phase L 3. | R | — A | — | u 16_current_deciamp | tlx:output_3_amperage | Output 3 Amperage |
 | 3036 | AC phase L 3 power | Active power exported on phase L 3. | R | — W | — | u 32_power_w_decawatt | tlx:output_3_power | Output 3 Wattage |
+| 3038 | RS line voltage | Line-to-line voltage between phases R and S measured on the AC output. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3039 | ST line voltage | Line-to-line voltage between phases S and T measured on the AC output. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3040 | TR line voltage | Line-to-line voltage between phases T and R measured on the AC output. | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3041 | Load supply power | Real-time active power delivered to on-site (self-consumption) loads. | R | — W | — | u 32_power_w_decawatt | tlx:power_to_user | Power to user |
 | 3043 | Grid export power | Active power exported to the utility grid. | R | — W | — | u 32_power_w_decawatt | tlx:power_to_grid | Power to grid |
 | 3045 | Home load power | Aggregate instantaneous demand from on-site loads. | R | — W | — | u 32_power_w_decawatt | tlx:power_user_load | Power user load |
@@ -521,18 +525,42 @@ Primary TL-X/TL-XH telemetry mirror (PV/AC metrics).
 | 3069 | Load energy total | Lifetime energy delivered to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:energy_to_user_total | Energy To User (Total) |
 | 3071 | Export energy today | Energy exported to the grid today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:energy_to_grid_today | Energy To Grid (Today) |
 | 3073 | Export energy total | Lifetime energy exported to the grid (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:energy_to_grid_total | Energy To Grid (Total) |
+| 3075 | User load energy today | Energy delivered to on-site loads today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3077 | User load energy total | Lifetime energy delivered to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3079 | PV 4 energy today | Energy harvested by PV string 4 today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3081 | PV 4 energy total | Lifetime energy harvested by PV string 4 (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3083 | PV energy today | Total PV energy harvested across all strings today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
 | 3086 | Derating mode | Active derating reason reported by the inverter controller. | R | — | — | u 16_raw_code | tlx:derating_mode | Derating mode |
+| 3087 | PV insulation resistance | DC insulation resistance measured on the PV inputs. | R | — kΩ | — | u 16_resistance_kiloohm | — | — |
+| 3088 | Residual current R | Ground fault residual current on phase R (0.1 m A resolution). | R | — m A | — | u 16_current_decimilliamp | — | — |
+| 3089 | Residual current S | Ground fault residual current on phase S (0.1 m A resolution). | R | — m A | — | u 16_current_decimilliamp | — | — |
+| 3090 | Residual current T | Ground fault residual current on phase T (0.1 m A resolution). | R | — m A | — | u 16_current_decimilliamp | — | — |
+| 3091 | GFCI current | Ground fault current measured by the GFCI sensor (1 m A resolution). | R | — m A | — | u 16_current_milliamp | — | — |
+| 3092 | Total bus voltage | Combined DC bus voltage measured at the inverter bridge (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3093 | Inverter temperature | Main inverter heatsink temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:inverter_temperature | Temperature |
 | 3094 | IPM temperature | IPM (power module) temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:ipm_temperature | Intelligent Power Management temperature |
 | 3095 | Boost temperature | Boost inductor temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:boost_temperature | Boost temperature |
 | 3097 | Communication board temperature | Temperature reported by the communication/control board (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:comm_board_temperature | Comm board temperature |
 | 3098 | P-bus voltage | Positive DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | tlx:p_bus_voltage | P-bus voltage |
 | 3099 | N-bus voltage | Negative DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | tlx:n_bus_voltage | N-bus voltage |
+| 3100 | Inverter output power factor | Instantaneous output power factor encoded as value ×10 000 (10 000 = unity). | R | — pf | — | power_factor_x 10000 | — | — |
 | 3101 | Output power percentage | Instantaneous AC output as a percentage of the inverter's rated power. | R | — % | — | u 16_percent | tlx:real_output_power_percent | Real power output percentage |
+| 3102 | Output max power limit | Current active output power limit enforced by the inverter (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3104 | Standby flags | Bitmask reporting standby reasons for the inverter (vendor-defined). | R | — | — | u 16_status_word | — | — |
 | 3105 | Fault code | Current inverter fault code (see protocol documentation). | R | — | — | u 16_status_word | tlx:fault_code | Fault code |
+| 3106 | Warning main code | Current warning main code reported by the inverter controller. | R | — | — | u 16_raw_code | — | — |
+| 3107 | Fault subcode | Fault detail bitmask identifying the root cause of the active fault. | R | — | — | u 16_status_word | — | — |
+| 3108 | Warning subcode | Warning detail bitmask reported alongside the main warning code. | R | — | — | u 16_status_word | — | — |
 | 3110 | Warning code | Current inverter warning code (vendor-defined bitmask). | R | — | — | u 16_status_word | tlx:warning_code | Warning code |
 | 3111 | Present FFT value (channel A) | Latest Fast Fourier Transform diagnostic value for channel A. | R | — | — | u 16_raw | tlx:present_fft_a | Present FFT A |
+| 3112 | AFCI status | Arc-fault detection controller status word. | R | — | — | u 16_raw_code | — | — |
+| 3113 | AFCI strength (channel A) | Arc-fault detection strength metric for channel A. | R | — | — | u 16_raw | — | — |
+| 3114 | AFCI self-check (channel A) | Result of the AFCI self-test for channel A. | R | — | — | u 16_raw | — | — |
 | 3115 | Inverter start delay | Seconds remaining before restart once grid conditions recover. | R | — s | — | u 16_raw | tlx:inv_start_delay | Inverter start delay |
+| 3118 | BDC connect state | Indicates whether the battery DC converter is connected (0 = off, 1 = on). | R | — | — | bdc_onoff_state_flag | — | — |
+| 3119 | Dry contact state | Status of the dry contact output (0 = open, 1 = closed). | R | — | — | boolean_flag | — | — |
+| 3121 | Self-use power | Real-time power consumed by on-site loads (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3123 | System energy today | Total energy processed by the hybrid system today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
 
 ## TL-X/TL-XH Battery & Hybrid Input Registers (3125–3249)
 Battery energy, power flow, and BMS telemetry for TL-XH hybrids.
@@ -545,7 +573,31 @@ Battery energy, power flow, and BMS telemetry for TL-XH hybrids.
 | 3127 | Battery discharge total | Total energy discharged from the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:discharge_energy_total, storage:discharge_energy_total | Battery Discharged (Total), Battery Discharged Lifetime |
 | 3129 | Battery charge today | Energy charged into the battery today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:charge_energy_today, storage:charge_energy_today | Battery Charged (Today), Battery Charged Today |
 | 3131 | Battery charge total | Total energy charged into the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | tlx:charge_energy_total, storage:charge_energy_total | Battery Charged (Total), Grid Charged Lifetime |
+| 3133 | AC charge energy today | Energy charged into the battery from AC today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3135 | AC charge energy total | Lifetime energy charged into the battery from AC (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3137 | System energy total | Lifetime hybrid system energy throughput (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3139 | Self-use energy today | Energy supplied to on-site loads today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3141 | Self-use energy total | Lifetime energy supplied to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3144 | Priority mode | Operating priority mode: 0 = load-first, 1 = battery-first, 2 = grid-first. | R | — | — | priority_mode | — | — |
+| 3145 | EPS frequency | Output frequency of the EPS (backup) inverter (0.01 Hz resolution). | R | — Hz | — | u 16_frequency_centihz | — | — |
+| 3146 | EPS phase R voltage | Phase R voltage on the EPS output (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3147 | EPS phase R current | Phase R current on the EPS output (0.1 A resolution). | R | — A | — | u 16_current_deciamp | — | — |
+| 3148 | EPS phase R apparent power | Phase R apparent power on the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3150 | EPS phase S voltage | Phase S voltage on the EPS output (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3151 | EPS phase S current | Phase S current on the EPS output (0.1 A resolution). | R | — A | — | u 16_current_deciamp | — | — |
+| 3152 | EPS phase S apparent power | Phase S apparent power on the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3154 | EPS phase T voltage | Phase T voltage on the EPS output (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3155 | EPS phase T current | Phase T current on the EPS output (0.1 A resolution). | R | — A | — | u 16_current_deciamp | — | — |
+| 3156 | EPS phase T apparent power | Phase T apparent power on the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3158 | EPS total apparent power | Total apparent power delivered by the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3160 | EPS load percentage | Utilisation of the EPS output expressed as a percentage of rating (0.1 % resolution). | R | — % | — | u 16_percent_decitenth | — | — |
+| 3161 | BDC power factor | Battery DC converter power factor estimate (0.1 resolution). | R | — pf | — | u 16_power_factor_decitenth | — | — |
+| 3162 | BDC DC voltage | High-voltage DC bus measurement from the BDC (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | — | — |
 | 3164 | BDC presence flag | Indicates whether a battery DC converter (BDC) has been detected. | R | — | — | u 16_flag | tlx:bdc_new_flag, storage:bdc_new_flag | BDC present |
+| 3165 | BDC derating mode | Derating reason code reported by the battery DC converter. | R | — | — | u 16_raw_code | — | — |
+| 3166 | BDC system mode | Operating state reported by the battery DC converter controller. | R | — | — | u 16_raw_code | — | — |
+| 3167 | BDC fault code | Current fault code reported by the battery DC converter. | R | — | — | u 16_raw_code | — | — |
+| 3168 | BDC warning code | Current warning code reported by the battery DC converter. | R | — | — | u 16_raw_code | — | — |
 | 3169 | Battery voltage | Pack voltage reported via the inverter-side measurements (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | tlx:battery_voltage, storage:battery_voltage | Battery voltage |
 | 3170 | Battery current | Current flowing between battery and inverter (positive = discharge) with 0.1 A resolution. | R | — A | — | s 16_current_deciamp | tlx:battery_current, storage:battery_current | Battery current |
 | 3171 | Battery SOC | Battery state of charge reported by the inverter. | R | — % | — | u 16_percent | tlx:soc, storage:soc | SOC |
@@ -557,6 +609,10 @@ Battery energy, power flow, and BMS telemetry for TL-XH hybrids.
 | 3177 | Battery temperature B | Battery temperature sensor B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:battery_temperature_b, storage:battery_temperature_b | Battery temperature B |
 | 3178 | Battery discharge power | Real-time discharge power flowing from the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | tlx:discharge_power, storage:discharge_power | Battery discharge power, Discharge Power |
 | 3180 | Battery charge power | Real-time charge power flowing into the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | tlx:charge_power, storage:charge_power | Battery charge power, Charge Power |
+| 3182 | BDC discharge energy total | Lifetime energy discharged by the battery DC converter (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3184 | BDC charge energy total | Lifetime energy charged into the battery via the BDC (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3187 | BDC flag word | Diagnostic flag bitmask reported by the battery DC converter. | R | — | — | u 16_status_word | — | — |
+| 3188 | VBUS 2 low voltage | Low-side DC bus voltage reported by the BDC (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3189 | BMS max cell index | Cell index reporting the highest voltage in the battery stack (1-based). | R | — | — | u 16_raw | tlx:bms_max_volt_cell_no, storage:bms_max_volt_cell_no | BMS max volt cell no |
 | 3190 | BMS min cell index | Cell index reporting the lowest voltage in the battery stack (1-based). | R | — | — | u 16_raw | tlx:bms_min_volt_cell_no, storage:bms_min_volt_cell_no | BMS min volt cell no |
 | 3191 | BMS average temperature A | Average temperature reported by sensor group A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | tlx:bms_avg_temp_a, storage:bms_avg_temp_a | BMS avg temp A |
@@ -593,6 +649,23 @@ Battery energy, power flow, and BMS telemetry for TL-XH hybrids.
 | 3226 | BMS protect flags 3 | Protection bitmask word 3 from the battery management system. | R | — | — | u 16_raw | tlx:bms_protect3, storage:bms_protect3 | BMS protect 3 |
 | 3230 | BMS max cell voltage | Highest individual cell voltage (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | tlx:bms_cell_volt_max, storage:bms_cell_volt_max | BMS cell voltage max |
 | 3231 | BMS min cell voltage | Lowest individual cell voltage (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | tlx:bms_cell_volt_min, storage:bms_cell_volt_min | BMS cell voltage min |
+| 3232 | Battery load voltage | Battery-side load voltage measurement (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | — | — |
+| 3234 | Debug data 1 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3235 | Debug data 2 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3236 | Debug data 3 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3237 | Debug data 4 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3238 | Debug data 5 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3239 | Debug data 6 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3240 | Debug data 7 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3241 | Debug data 8 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3242 | Debug data 9 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3243 | Debug data 10 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3244 | Debug data 11 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3245 | Debug data 12 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3246 | Debug data 13 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3247 | Debug data 14 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3248 | Debug data 15 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3249 | Debug data 16 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
 
 ## Storage TL-XH Input Registers (3041–3231)
 BDC telemetry (battery module data) for TL-XH hybrids.
@@ -618,23 +691,71 @@ BDC telemetry (battery module data) for TL-XH hybrids.
 | 3069 | Load energy total | Lifetime energy delivered to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:energy_to_user_total | Energy To User (Total) |
 | 3071 | Export energy today | Energy exported to the grid today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:energy_to_grid_today | Energy To Grid (Today) |
 | 3073 | Export energy total | Lifetime energy exported to the grid (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:energy_to_grid_total | Energy To Grid (Total) |
+| 3075 | User load energy today | Energy delivered to on-site loads today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3077 | User load energy total | Lifetime energy delivered to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3079 | PV 4 energy today | Energy harvested by PV string 4 today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3081 | PV 4 energy total | Lifetime energy harvested by PV string 4 (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3083 | PV energy today | Total PV energy harvested across all strings today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
 | 3086 | Derating mode | Active derating reason reported by the inverter controller. | R | — | — | u 16_raw_code | — | — |
+| 3087 | PV insulation resistance | DC insulation resistance measured on the PV inputs. | R | — kΩ | — | u 16_resistance_kiloohm | — | — |
+| 3088 | Residual current R | Ground fault residual current on phase R (0.1 m A resolution). | R | — m A | — | u 16_current_decimilliamp | — | — |
+| 3089 | Residual current S | Ground fault residual current on phase S (0.1 m A resolution). | R | — m A | — | u 16_current_decimilliamp | — | — |
+| 3090 | Residual current T | Ground fault residual current on phase T (0.1 m A resolution). | R | — m A | — | u 16_current_decimilliamp | — | — |
+| 3091 | GFCI current | Ground fault current measured by the GFCI sensor (1 m A resolution). | R | — m A | — | u 16_current_milliamp | — | — |
+| 3092 | Total bus voltage | Combined DC bus voltage measured at the inverter bridge (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3093 | Inverter temperature | Main inverter heatsink temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
 | 3094 | IPM temperature | IPM (power module) temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
 | 3095 | Boost temperature | Boost inductor temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
 | 3097 | Communication board temperature | Temperature reported by the communication/control board (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:comm_board_temperature | Comm board temperature |
 | 3098 | P-bus voltage | Positive DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3099 | N-bus voltage | Negative DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3100 | Inverter output power factor | Instantaneous output power factor encoded as value ×10 000 (10 000 = unity). | R | — pf | — | power_factor_x 10000 | — | — |
 | 3101 | Output power percentage | Instantaneous AC output as a percentage of the inverter's rated power. | R | — % | — | u 16_percent | — | — |
+| 3102 | Output max power limit | Current active output power limit enforced by the inverter (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3104 | Standby flags | Bitmask reporting standby reasons for the inverter (vendor-defined). | R | — | — | u 16_status_word | — | — |
 | 3105 | Fault code | Current inverter fault code (see protocol documentation). | R | — | — | u 16_status_word | — | — |
+| 3106 | Warning main code | Current warning main code reported by the inverter controller. | R | — | — | u 16_raw_code | — | — |
+| 3107 | Fault subcode | Fault detail bitmask identifying the root cause of the active fault. | R | — | — | u 16_status_word | — | — |
+| 3108 | Warning subcode | Warning detail bitmask reported alongside the main warning code. | R | — | — | u 16_status_word | — | — |
 | 3110 | Warning code | Current inverter warning code (vendor-defined bitmask). | R | — | — | u 16_status_word | — | — |
 | 3111 | Present FFT value (channel A) | Latest Fast Fourier Transform diagnostic value for channel A. | R | — | — | u 16_raw | storage:present_fft_a | Present FFT A |
+| 3112 | AFCI status | Arc-fault detection controller status word. | R | — | — | u 16_raw_code | — | — |
+| 3113 | AFCI strength (channel A) | Arc-fault detection strength metric for channel A. | R | — | — | u 16_raw | — | — |
+| 3114 | AFCI self-check (channel A) | Result of the AFCI self-test for channel A. | R | — | — | u 16_raw | — | — |
 | 3115 | Inverter start delay | Seconds remaining before restart once grid conditions recover. | R | — s | — | u 16_raw | storage:inv_start_delay | Inverter start delay |
+| 3118 | BDC connect state | Indicates whether the battery DC converter is connected (0 = off, 1 = on). | R | — | — | bdc_onoff_state_flag | — | — |
+| 3119 | Dry contact state | Status of the dry contact output (0 = open, 1 = closed). | R | — | — | boolean_flag | — | — |
+| 3121 | Self-use power | Real-time power consumed by on-site loads (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3123 | System energy today | Total energy processed by the hybrid system today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
 | 3125 | Battery discharge today | Energy discharged from the battery into the AC system today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:discharge_energy_today | Battery Discharged (Today), Battery Discharged Today |
 | 3127 | Battery discharge total | Total energy discharged from the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:discharge_energy_total | Battery Discharged (Total), Battery Discharged Lifetime |
 | 3129 | Battery charge today | Energy charged into the battery today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:charge_energy_today | Battery Charged (Today), Battery Charged Today |
 | 3131 | Battery charge total | Total energy charged into the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | storage:charge_energy_total | Battery Charged (Total), Grid Charged Lifetime |
+| 3133 | AC charge energy today | Energy charged into the battery from AC today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3135 | AC charge energy total | Lifetime energy charged into the battery from AC (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3137 | System energy total | Lifetime hybrid system energy throughput (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3139 | Self-use energy today | Energy supplied to on-site loads today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3141 | Self-use energy total | Lifetime energy supplied to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3144 | Priority mode | Operating priority mode: 0 = load-first, 1 = battery-first, 2 = grid-first. | R | — | — | priority_mode | — | — |
+| 3145 | EPS frequency | Output frequency of the EPS (backup) inverter (0.01 Hz resolution). | R | — Hz | — | u 16_frequency_centihz | — | — |
+| 3146 | EPS phase R voltage | Phase R voltage on the EPS output (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3147 | EPS phase R current | Phase R current on the EPS output (0.1 A resolution). | R | — A | — | u 16_current_deciamp | — | — |
+| 3148 | EPS phase R apparent power | Phase R apparent power on the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3150 | EPS phase S voltage | Phase S voltage on the EPS output (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3151 | EPS phase S current | Phase S current on the EPS output (0.1 A resolution). | R | — A | — | u 16_current_deciamp | — | — |
+| 3152 | EPS phase S apparent power | Phase S apparent power on the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3154 | EPS phase T voltage | Phase T voltage on the EPS output (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3155 | EPS phase T current | Phase T current on the EPS output (0.1 A resolution). | R | — A | — | u 16_current_deciamp | — | — |
+| 3156 | EPS phase T apparent power | Phase T apparent power on the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3158 | EPS total apparent power | Total apparent power delivered by the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3160 | EPS load percentage | Utilisation of the EPS output expressed as a percentage of rating (0.1 % resolution). | R | — % | — | u 16_percent_decitenth | — | — |
+| 3161 | BDC power factor | Battery DC converter power factor estimate (0.1 resolution). | R | — pf | — | u 16_power_factor_decitenth | — | — |
+| 3162 | BDC DC voltage | High-voltage DC bus measurement from the BDC (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | — | — |
 | 3164 | BDC presence flag | Indicates whether a battery DC converter (BDC) has been detected. | R | — | — | u 16_flag | storage:bdc_new_flag | BDC present |
+| 3165 | BDC derating mode | Derating reason code reported by the battery DC converter. | R | — | — | u 16_raw_code | — | — |
+| 3166 | BDC system mode | Operating state reported by the battery DC converter controller. | R | — | — | u 16_raw_code | — | — |
+| 3167 | BDC fault code | Current fault code reported by the battery DC converter. | R | — | — | u 16_raw_code | — | — |
+| 3168 | BDC warning code | Current warning code reported by the battery DC converter. | R | — | — | u 16_raw_code | — | — |
 | 3169 | Battery voltage | Pack voltage reported via the inverter-side measurements (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | storage:battery_voltage | Battery voltage |
 | 3170 | Battery current | Current flowing between battery and inverter (positive = discharge) with 0.1 A resolution. | R | — A | — | s 16_current_deciamp | storage:battery_current | Battery current |
 | 3171 | Battery SOC | Battery state of charge reported by the inverter. | R | — % | — | u 16_percent | storage:soc | SOC |
@@ -646,6 +767,10 @@ BDC telemetry (battery module data) for TL-XH hybrids.
 | 3177 | Battery temperature B | Battery temperature sensor B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:battery_temperature_b | Battery temperature B |
 | 3178 | Battery discharge power | Real-time discharge power flowing from the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | storage:discharge_power | Battery discharge power, Discharge Power |
 | 3180 | Battery charge power | Real-time charge power flowing into the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | storage:charge_power | Battery charge power, Charge Power |
+| 3182 | BDC discharge energy total | Lifetime energy discharged by the battery DC converter (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3184 | BDC charge energy total | Lifetime energy charged into the battery via the BDC (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3187 | BDC flag word | Diagnostic flag bitmask reported by the battery DC converter. | R | — | — | u 16_status_word | — | — |
+| 3188 | VBUS 2 low voltage | Low-side DC bus voltage reported by the BDC (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3189 | BMS max cell index | Cell index reporting the highest voltage in the battery stack (1-based). | R | — | — | u 16_raw | storage:bms_max_volt_cell_no | BMS max volt cell no |
 | 3190 | BMS min cell index | Cell index reporting the lowest voltage in the battery stack (1-based). | R | — | — | u 16_raw | storage:bms_min_volt_cell_no | BMS min volt cell no |
 | 3191 | BMS average temperature A | Average temperature reported by sensor group A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | storage:bms_avg_temp_a | BMS avg temp A |
@@ -772,6 +897,7 @@ Observed off-grid register map (from integration implementation).
 | 3015 | PV 4 DC voltage | Instantaneous PV 4 string voltage measured at the inverter input. | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3016 | PV 4 DC current | Instantaneous PV 4 string current flowing into the inverter. | R | — A | — | u 16_current_deciamp | — | — |
 | 3017 | PV 4 DC power | Real-time DC power from PV 4 computed from voltage and current readings. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3019 | System output power | AC output power reported by the TL-XH mirror block (0.1 W resolution). Mirrors the value at register 35. | R | — W | — | u 32_power_w_decawatt | — | — |
 | 3021 | Output reactive power | Instantaneous reactive power on the AC output (positive = inductive, negative = capacitive). | R | — var | — | s 32_reactive_power_decivar | — | — |
 | 3023 | AC output power | Active AC output power delivered by the inverter (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | — | — |
 | 3025 | Grid frequency | Measured grid frequency with 0.01 Hz resolution. | R | — Hz | — | u 16_frequency_centihz | — | — |
@@ -784,6 +910,9 @@ Observed off-grid register map (from integration implementation).
 | 3034 | AC phase L 3 voltage | AC output voltage for phase L 3. | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3035 | AC phase L 3 current | AC output current for phase L 3. | R | — A | — | u 16_current_deciamp | — | — |
 | 3036 | AC phase L 3 power | Active power exported on phase L 3. | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3038 | RS line voltage | Line-to-line voltage between phases R and S measured on the AC output. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3039 | ST line voltage | Line-to-line voltage between phases S and T measured on the AC output. | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3040 | TR line voltage | Line-to-line voltage between phases T and R measured on the AC output. | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3041 | Load supply power | Real-time active power delivered to on-site (self-consumption) loads. | R | — W | — | u 32_power_w_decawatt | — | — |
 | 3043 | Grid export power | Active power exported to the utility grid. | R | — W | — | u 32_power_w_decawatt | — | — |
 | 3045 | Home load power | Aggregate instantaneous demand from on-site loads. | R | — W | — | u 32_power_w_decawatt | — | — |
@@ -801,23 +930,71 @@ Observed off-grid register map (from integration implementation).
 | 3069 | Load energy total | Lifetime energy delivered to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
 | 3071 | Export energy today | Energy exported to the grid today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
 | 3073 | Export energy total | Lifetime energy exported to the grid (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3075 | User load energy today | Energy delivered to on-site loads today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3077 | User load energy total | Lifetime energy delivered to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3079 | PV 4 energy today | Energy harvested by PV string 4 today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3081 | PV 4 energy total | Lifetime energy harvested by PV string 4 (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3083 | PV energy today | Total PV energy harvested across all strings today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
 | 3086 | Derating mode | Active derating reason reported by the inverter controller. | R | — | — | u 16_raw_code | — | — |
+| 3087 | PV insulation resistance | DC insulation resistance measured on the PV inputs. | R | — kΩ | — | u 16_resistance_kiloohm | — | — |
+| 3088 | Residual current R | Ground fault residual current on phase R (0.1 m A resolution). | R | — m A | — | u 16_current_decimilliamp | — | — |
+| 3089 | Residual current S | Ground fault residual current on phase S (0.1 m A resolution). | R | — m A | — | u 16_current_decimilliamp | — | — |
+| 3090 | Residual current T | Ground fault residual current on phase T (0.1 m A resolution). | R | — m A | — | u 16_current_decimilliamp | — | — |
+| 3091 | GFCI current | Ground fault current measured by the GFCI sensor (1 m A resolution). | R | — m A | — | u 16_current_milliamp | — | — |
+| 3092 | Total bus voltage | Combined DC bus voltage measured at the inverter bridge (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3093 | Inverter temperature | Main inverter heatsink temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
 | 3094 | IPM temperature | IPM (power module) temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
 | 3095 | Boost temperature | Boost inductor temperature (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
 | 3097 | Communication board temperature | Temperature reported by the communication/control board (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
 | 3098 | P-bus voltage | Positive DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3099 | N-bus voltage | Negative DC bus voltage (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3100 | Inverter output power factor | Instantaneous output power factor encoded as value ×10 000 (10 000 = unity). | R | — pf | — | power_factor_x 10000 | — | — |
 | 3101 | Output power percentage | Instantaneous AC output as a percentage of the inverter's rated power. | R | — % | — | u 16_percent | — | — |
+| 3102 | Output max power limit | Current active output power limit enforced by the inverter (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3104 | Standby flags | Bitmask reporting standby reasons for the inverter (vendor-defined). | R | — | — | u 16_status_word | — | — |
 | 3105 | Fault code | Current inverter fault code (see protocol documentation). | R | — | — | u 16_status_word | — | — |
+| 3106 | Warning main code | Current warning main code reported by the inverter controller. | R | — | — | u 16_raw_code | — | — |
+| 3107 | Fault subcode | Fault detail bitmask identifying the root cause of the active fault. | R | — | — | u 16_status_word | — | — |
+| 3108 | Warning subcode | Warning detail bitmask reported alongside the main warning code. | R | — | — | u 16_status_word | — | — |
 | 3110 | Warning code | Current inverter warning code (vendor-defined bitmask). | R | — | — | u 16_status_word | — | — |
 | 3111 | Present FFT value (channel A) | Latest Fast Fourier Transform diagnostic value for channel A. | R | — | — | u 16_raw | — | — |
+| 3112 | AFCI status | Arc-fault detection controller status word. | R | — | — | u 16_raw_code | — | — |
+| 3113 | AFCI strength (channel A) | Arc-fault detection strength metric for channel A. | R | — | — | u 16_raw | — | — |
+| 3114 | AFCI self-check (channel A) | Result of the AFCI self-test for channel A. | R | — | — | u 16_raw | — | — |
 | 3115 | Inverter start delay | Seconds remaining before restart once grid conditions recover. | R | — s | — | u 16_raw | — | — |
+| 3118 | BDC connect state | Indicates whether the battery DC converter is connected (0 = off, 1 = on). | R | — | — | bdc_onoff_state_flag | — | — |
+| 3119 | Dry contact state | Status of the dry contact output (0 = open, 1 = closed). | R | — | — | boolean_flag | — | — |
+| 3121 | Self-use power | Real-time power consumed by on-site loads (0.1 W resolution). | R | — W | — | u 32_power_w_decawatt | — | — |
+| 3123 | System energy today | Total energy processed by the hybrid system today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
 | 3125 | Battery discharge today | Energy discharged from the battery into the AC system today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
 | 3127 | Battery discharge total | Total energy discharged from the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
 | 3129 | Battery charge today | Energy charged into the battery today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
 | 3131 | Battery charge total | Total energy charged into the battery (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3133 | AC charge energy today | Energy charged into the battery from AC today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3135 | AC charge energy total | Lifetime energy charged into the battery from AC (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3137 | System energy total | Lifetime hybrid system energy throughput (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3139 | Self-use energy today | Energy supplied to on-site loads today (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3141 | Self-use energy total | Lifetime energy supplied to on-site loads (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3144 | Priority mode | Operating priority mode: 0 = load-first, 1 = battery-first, 2 = grid-first. | R | — | — | priority_mode | — | — |
+| 3145 | EPS frequency | Output frequency of the EPS (backup) inverter (0.01 Hz resolution). | R | — Hz | — | u 16_frequency_centihz | — | — |
+| 3146 | EPS phase R voltage | Phase R voltage on the EPS output (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3147 | EPS phase R current | Phase R current on the EPS output (0.1 A resolution). | R | — A | — | u 16_current_deciamp | — | — |
+| 3148 | EPS phase R apparent power | Phase R apparent power on the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3150 | EPS phase S voltage | Phase S voltage on the EPS output (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3151 | EPS phase S current | Phase S current on the EPS output (0.1 A resolution). | R | — A | — | u 16_current_deciamp | — | — |
+| 3152 | EPS phase S apparent power | Phase S apparent power on the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3154 | EPS phase T voltage | Phase T voltage on the EPS output (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
+| 3155 | EPS phase T current | Phase T current on the EPS output (0.1 A resolution). | R | — A | — | u 16_current_deciamp | — | — |
+| 3156 | EPS phase T apparent power | Phase T apparent power on the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3158 | EPS total apparent power | Total apparent power delivered by the EPS output (0.1 VA resolution). | R | — VA | — | u 32_apparent_power_decava | — | — |
+| 3160 | EPS load percentage | Utilisation of the EPS output expressed as a percentage of rating (0.1 % resolution). | R | — % | — | u 16_percent_decitenth | — | — |
+| 3161 | BDC power factor | Battery DC converter power factor estimate (0.1 resolution). | R | — pf | — | u 16_power_factor_decitenth | — | — |
+| 3162 | BDC DC voltage | High-voltage DC bus measurement from the BDC (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | — | — |
 | 3164 | BDC presence flag | Indicates whether a battery DC converter (BDC) has been detected. | R | — | — | u 16_flag | — | — |
+| 3165 | BDC derating mode | Derating reason code reported by the battery DC converter. | R | — | — | u 16_raw_code | — | — |
+| 3166 | BDC system mode | Operating state reported by the battery DC converter controller. | R | — | — | u 16_raw_code | — | — |
+| 3167 | BDC fault code | Current fault code reported by the battery DC converter. | R | — | — | u 16_raw_code | — | — |
+| 3168 | BDC warning code | Current warning code reported by the battery DC converter. | R | — | — | u 16_raw_code | — | — |
 | 3169 | Battery voltage | Pack voltage reported via the inverter-side measurements (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | — | — |
 | 3170 | Battery current | Current flowing between battery and inverter (positive = discharge) with 0.1 A resolution. | R | — A | — | s 16_current_deciamp | — | — |
 | 3171 | Battery SOC | Battery state of charge reported by the inverter. | R | — % | — | u 16_percent | — | — |
@@ -829,6 +1006,10 @@ Observed off-grid register map (from integration implementation).
 | 3177 | Battery temperature B | Battery temperature sensor B (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
 | 3178 | Battery discharge power | Real-time discharge power flowing from the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | — | — |
 | 3180 | Battery charge power | Real-time charge power flowing into the battery (0.1 W resolution). | R | — W | — | s 32_power_w_decawatt | — | — |
+| 3182 | BDC discharge energy total | Lifetime energy discharged by the battery DC converter (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3184 | BDC charge energy total | Lifetime energy charged into the battery via the BDC (0.1 k Wh resolution). | R | — k Wh | — | u 32_energy_kwh_decitenth | — | — |
+| 3187 | BDC flag word | Diagnostic flag bitmask reported by the battery DC converter. | R | — | — | u 16_status_word | — | — |
+| 3188 | VBUS 2 low voltage | Low-side DC bus voltage reported by the BDC (0.1 V resolution). | R | — V | — | u 16_voltage_decivolt | — | — |
 | 3189 | BMS max cell index | Cell index reporting the highest voltage in the battery stack (1-based). | R | — | — | u 16_raw | — | — |
 | 3190 | BMS min cell index | Cell index reporting the lowest voltage in the battery stack (1-based). | R | — | — | u 16_raw | — | — |
 | 3191 | BMS average temperature A | Average temperature reported by sensor group A (0.1 °C resolution). | R | — °C | — | s 16_temperature_decic | — | — |
@@ -865,4 +1046,21 @@ Observed off-grid register map (from integration implementation).
 | 3226 | BMS protect flags 3 | Protection bitmask word 3 from the battery management system. | R | — | — | u 16_raw | — | — |
 | 3230 | BMS max cell voltage | Highest individual cell voltage (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | — | — |
 | 3231 | BMS min cell voltage | Lowest individual cell voltage (0.001 V resolution). | R | — V | — | u 16_voltage_millivolt | — | — |
+| 3232 | Battery load voltage | Battery-side load voltage measurement (0.01 V resolution). | R | — V | — | u 16_voltage_centivolt | — | — |
+| 3234 | Debug data 1 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3235 | Debug data 2 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3236 | Debug data 3 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3237 | Debug data 4 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3238 | Debug data 5 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3239 | Debug data 6 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3240 | Debug data 7 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3241 | Debug data 8 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3242 | Debug data 9 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3243 | Debug data 10 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3244 | Debug data 11 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3245 | Debug data 12 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3246 | Debug data 13 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3247 | Debug data 14 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3248 | Debug data 15 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
+| 3249 | Debug data 16 | Vendor-specific diagnostic word. | R | — | — | u 16_raw | — | — |
 


### PR DESCRIPTION
## Summary
- Documented the missing TL-XH mirrored PV/AC telemetry, energy counters and BDC/EPS diagnostics in the JSON spec and regenerated the Markdown tables.
- Added new kΩ/mA/apparent power data types and register type mappings so the TL-XH catalogue remains aligned with the integration metadata.

## Testing
- `python doc/render_register_spec.py`
- `pytest` *(fails: ModuleNotFoundError: homeassistant.util)*

------
https://chatgpt.com/codex/tasks/task_e_68cddb1405c8833085412c84ef38eb49